### PR TITLE
Manually sync recent missed CLs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Currently we provide precompiled libraries. See the following page for instructi
 * [iOS](https://github.com/google/nearby/blob/master/docs/ios_build.md)
 
 
-**Last Updated:** Feb 2022
+**Last Updated:** Febrary 2022

--- a/connections/implementation/proto/offline_wire_formats.proto
+++ b/connections/implementation/proto/offline_wire_formats.proto
@@ -89,6 +89,10 @@ message ConnectionRequestFrame {
   optional MediumMetadata medium_metadata = 7;
   optional int32 keep_alive_interval_millis = 8;
   optional int32 keep_alive_timeout_millis = 9;
+  // The type of {@link Device} object.
+  optional int32 device_type = 10 [default = 0];
+  // The bytes of serialized {@link Device} object.
+  optional bytes device_info = 11;
 }
 
 message ConnectionResponseFrame {

--- a/connections/implementation/proto/offline_wire_formats.proto
+++ b/connections/implementation/proto/offline_wire_formats.proto
@@ -143,7 +143,9 @@ message PayloadTransferFrame {
 
   // Accompanies DATA packets.
   message PayloadChunk {
-    enum Flags { LAST_CHUNK = 0x1; }
+    enum Flags {
+      LAST_CHUNK = 0x1;
+    }
     optional int32 flags = 1;
     optional int64 offset = 2;
     optional bytes body = 3;


### PR DESCRIPTION
(caused by proto enum reverse issue)

error msg like: 

0223 17:11:21.690 ERROR: Non reversible transformations:
diff --git a/origin/google3/third_party/nearby/connections/implementation/proto/offline_wire_formats.proto [b/reverse/google3/third_party/nearby/connections/implementation/proto/offline_wire_formats](http://b/reverse/google3/third_party/nearby/connections/implementation/proto/offline_wire_formats).proto
index de0aed4..5d4bb08 100644
--- a/origin/google3/third_party/nearby/connections/implementation/proto/offline_wire_formats.proto
+++ [b/reverse/google3/third_party/nearby/connections/implementation/proto/offline_wire_formats](http://b/reverse/google3/third_party/nearby/connections/implementation/proto/offline_wire_formats).proto
@@ -143,7 +143,9 @@ message PayloadTransferFrame {
 
   // Accompanies DATA packets.
   message PayloadChunk {
-    enum Flags { LAST_CHUNK = 0x1; }
+    enum Flags {
+      LAST_CHUNK = 0x1;
+    }
     optional int32 flags = 1;
     optional int64 offset = 2;
     optional bytes body = 3;