### PR TITLE
C++20 fixes.

### DIFF
--- a/connections/medium_selector.h
+++ b/connections/medium_selector.h
@@ -31,9 +31,6 @@ struct MediumSelector {
   T wifi_lan;
   T wifi_hotspot;
 
-  constexpr MediumSelector() = default;
-  constexpr MediumSelector(const MediumSelector&) = default;
-  constexpr MediumSelector& operator=(const MediumSelector&) = default;
   constexpr bool Any(T value) const {
     return bluetooth == value || ble == value || web_rtc == value ||
            wifi_lan == value || wifi_hotspot == value;


### PR DESCRIPTION
Structs with user-declared constructors are no longer aggregates.
Remove the user-declared constructors.

Bug: chromium:1284275