### PR TITLE
Give endpoint detail subviews IDs

### DIFF
--- a/connections/swift/NearbyConnections/Example/iOS Example/ConnectedView.swift
+++ b/connections/swift/NearbyConnections/Example/iOS Example/ConnectedView.swift
@@ -46,7 +46,8 @@ struct ConnectedView_Previews: PreviewProvider {
         Form {
             ConnectedView(
                 connection: ConnectedEndpoint(
-                    id: "",
+                    id: UUID(),
+                    endpointID: "",
                     endpointName: "Example"
                 ),
                 onSendBytes: {},

--- a/connections/swift/NearbyConnections/Example/iOS Example/ConnectionRequestView.swift
+++ b/connections/swift/NearbyConnections/Example/iOS Example/ConnectionRequestView.swift
@@ -42,7 +42,8 @@ struct ConnectionRequestView_Previews: PreviewProvider {
         Form {
             ConnectionRequestView(
                 connectionRequest: ConnectionRequest(
-                    id: "",
+                    id: UUID(),
+                    endpointID: "",
                     endpointName: "Example",
                     pin: "1234",
                     shouldAccept: { _ in }

--- a/connections/swift/NearbyConnections/Example/iOS Example/ContentView.swift
+++ b/connections/swift/NearbyConnections/Example/iOS Example/ContentView.swift
@@ -44,7 +44,7 @@ struct ContentView: View {
                 if !model.requests.isEmpty {
                     Section(header: Text("Pending Connections")) {
                         ForEach(model.requests) { request in
-                            NavigationLink(value: request.id) {
+                            NavigationLink(value: request.endpointID) {
                                 Text(request.endpointName)
                             }
                         }
@@ -54,7 +54,7 @@ struct ContentView: View {
                 if !model.connections.isEmpty {
                     Section(header: Text("Connections")) {
                         ForEach(model.connections) { connection in
-                            NavigationLink(value: connection.id) {
+                            NavigationLink(value: connection.endpointID) {
                                 Text(connection.endpointName)
                             }
                         }
@@ -64,7 +64,7 @@ struct ContentView: View {
                 if !model.endpoints.isEmpty {
                     Section(header: Text("Endpoints")) {
                         ForEach(model.endpoints) { endpoint in
-                            NavigationLink(value: endpoint.id) {
+                            NavigationLink(value: endpoint.endpointID) {
                                 Text(endpoint.endpointName)
                             }
                         }

--- a/connections/swift/NearbyConnections/Example/iOS Example/DiscoveredEndpointView.swift
+++ b/connections/swift/NearbyConnections/Example/iOS Example/DiscoveredEndpointView.swift
@@ -37,7 +37,8 @@ struct DiscoveredEndpointView_Previews: PreviewProvider {
         Form {
             DiscoveredEndpointView(
                 endpoint: DiscoveredEndpoint(
-                    id: "",
+                    id: UUID(),
+                    endpointID: "",
                     endpointName: "Example"
                 ),
                 onRequestConnection: {}

--- a/connections/swift/NearbyConnections/Example/iOS Example/EndpointDetail.swift
+++ b/connections/swift/NearbyConnections/Example/iOS Example/EndpointDetail.swift
@@ -22,16 +22,16 @@ struct EndpointDetail: View {
     @EnvironmentObject private var model: Model
 
     var body: some View {
-        let endpoint = model.endpoints.first { $0.id == endpointID }
-        let connectionRequest = model.requests.first { $0.id == endpointID }
-        let connection = model.connections.first { $0.id == endpointID }
+        let endpoint = model.endpoints.first { $0.endpointID == endpointID }
+        let connectionRequest = model.requests.first { $0.endpointID == endpointID }
+        let connection = model.connections.first { $0.endpointID == endpointID }
         let name = connectionRequest?.endpointName ?? connection?.endpointName ?? endpoint?.endpointName
 
         Form {
             if let endpoint {
                 DiscoveredEndpointView(endpoint: endpoint, onRequestConnection: {
                     model.requestConnection(to: endpointID)
-                })
+                }).id(endpoint.id)
             }
 
             if let connectionRequest {
@@ -39,7 +39,7 @@ struct EndpointDetail: View {
                     connectionRequest.shouldAccept(true)
                 }, onRejectConnection: {
                     connectionRequest.shouldAccept(false)
-                })
+                }).id(connectionRequest.id)
             }
 
             if let connection {
@@ -47,7 +47,7 @@ struct EndpointDetail: View {
                     model.sendBytes(to: [endpointID])
                 }, onDisconnect: {
                     model.disconnect(from: endpointID)
-                })
+                }).id(connection.id)
             }
         }
         .navigationTitle(name ?? "")

--- a/connections/swift/NearbyConnections/Example/iOS Example/Model/ConnectedEndpoint.swift
+++ b/connections/swift/NearbyConnections/Example/iOS Example/Model/ConnectedEndpoint.swift
@@ -18,7 +18,8 @@ import Foundation
 import NearbyConnections
 
 struct ConnectedEndpoint: Identifiable {
-    let id: EndpointID
+    let id: UUID
+    let endpointID: EndpointID
     let endpointName: String
     var payloads: [Payload] = []
 }

--- a/connections/swift/NearbyConnections/Example/iOS Example/Model/ConnectionRequest.swift
+++ b/connections/swift/NearbyConnections/Example/iOS Example/Model/ConnectionRequest.swift
@@ -18,7 +18,8 @@ import Foundation
 import NearbyConnections
 
 struct ConnectionRequest: Identifiable {
-    let id: EndpointID
+    let id: UUID
+    let endpointID: EndpointID
     let endpointName: String
     let pin: String
     let shouldAccept: ((Bool) -> Void)

--- a/connections/swift/NearbyConnections/Example/iOS Example/Model/DiscoveredEndpoint.swift
+++ b/connections/swift/NearbyConnections/Example/iOS Example/Model/DiscoveredEndpoint.swift
@@ -18,6 +18,7 @@ import Foundation
 import NearbyConnections
 
 struct DiscoveredEndpoint: Identifiable {
-    let id: EndpointID
+    let id: UUID
+    let endpointID: EndpointID
     let endpointName: String
 }

--- a/connections/swift/NearbyConnections/Example/iOS Example/Model/Model.swift
+++ b/connections/swift/NearbyConnections/Example/iOS Example/Model/Model.swift
@@ -110,7 +110,7 @@ class Model: ObservableObject {
             cancellationToken: token
         )
         for endpointID in endpointIDs {
-            guard let index = connections.firstIndex(where: { $0.id == endpointID }) else {
+            guard let index = connections.firstIndex(where: { $0.endpointID == endpointID }) else {
                 return
             }
             connections[index].payloads.insert(payload, at: 0)
@@ -121,14 +121,15 @@ class Model: ObservableObject {
 extension Model: DiscovererDelegate {
     func discoverer(_ discoverer: Discoverer, didFind endpointID: EndpointID, with context: Data) {
         let endpoint = DiscoveredEndpoint(
-            id: endpointID,
+            id: UUID(),
+            endpointID: endpointID,
             endpointName: String(data: context, encoding: .utf8)!
         )
         endpoints.insert(endpoint, at: 0)
     }
 
     func discoverer(_ discoverer: Discoverer, didLose endpointID: EndpointID) {
-        guard let index = endpoints.firstIndex(where: { $0.id == endpointID }) else {
+        guard let index = endpoints.firstIndex(where: { $0.endpointID == endpointID }) else {
             return
         }
         endpoints.remove(at: index)
@@ -138,7 +139,8 @@ extension Model: DiscovererDelegate {
 extension Model: AdvertiserDelegate {
     func advertiser(_ advertiser: Advertiser, didReceiveConnectionRequestFrom endpointID: EndpointID, with context: Data, connectionRequestHandler: @escaping (Bool) -> Void) {
         let endpoint = DiscoveredEndpoint(
-            id: endpointID,
+            id: UUID(),
+            endpointID: endpointID,
             endpointName: String(data: context, encoding: .utf8)!
         )
         endpoints.insert(endpoint, at: 0)
@@ -148,12 +150,13 @@ extension Model: AdvertiserDelegate {
 
 extension Model: ConnectionManagerDelegate {
     func connectionManager(_ connectionManager: ConnectionManager, didReceive verificationCode: String, from endpointID: EndpointID, verificationHandler: @escaping (Bool) -> Void) {
-        guard let index = endpoints.firstIndex(where: { $0.id == endpointID }) else {
+        guard let index = endpoints.firstIndex(where: { $0.endpointID == endpointID }) else {
             return
         }
         let endpoint = endpoints.remove(at: index)
         let request = ConnectionRequest(
-            id: endpointID,
+            id: endpoint.id,
+            endpointID: endpointID,
             endpointName: endpoint.endpointName,
             pin: verificationCode,
             shouldAccept: { accept in
@@ -171,7 +174,7 @@ extension Model: ConnectionManagerDelegate {
             isIncoming: true,
             cancellationToken: nil
         )
-        guard let index = connections.firstIndex(where: { $0.id == endpointID }) else {
+        guard let index = connections.firstIndex(where: { $0.endpointID == endpointID }) else {
             return
         }
         connections[index].payloads.insert(payload, at: 0)
@@ -185,7 +188,7 @@ extension Model: ConnectionManagerDelegate {
             isIncoming: true,
             cancellationToken: token
         )
-        guard let index = connections.firstIndex(where: { $0.id == endpointID }) else {
+        guard let index = connections.firstIndex(where: { $0.endpointID == endpointID }) else {
             return
         }
         connections[index].payloads.insert(payload, at: 0)
@@ -199,14 +202,14 @@ extension Model: ConnectionManagerDelegate {
             isIncoming: true,
             cancellationToken: token
         )
-        guard let index = connections.firstIndex(where: { $0.id == endpointID }) else {
+        guard let index = connections.firstIndex(where: { $0.endpointID == endpointID }) else {
             return
         }
         connections[index].payloads.insert(payload, at: 0)
     }
 
     func connectionManager(_ connectionManager: ConnectionManager, didReceiveTransferUpdate update: TransferUpdate, from endpointID: EndpointID, forPayload payloadID: PayloadID) {
-        guard let connectionIndex = connections.firstIndex(where: { $0.id == endpointID }),
+        guard let connectionIndex = connections.firstIndex(where: { $0.endpointID == endpointID }),
               let payloadIndex = connections[connectionIndex].payloads.firstIndex(where: { $0.id == payloadID }) else {
             return
         }
@@ -227,22 +230,23 @@ extension Model: ConnectionManagerDelegate {
         case .connecting:
             break
         case .connected:
-            guard let index = requests.firstIndex(where: { $0.id == endpointID }) else {
+            guard let index = requests.firstIndex(where: { $0.endpointID == endpointID }) else {
                 return
             }
             let request = requests.remove(at: index)
             let connection = ConnectedEndpoint(
-                id: endpointID,
+                id: request.id,
+                endpointID: endpointID,
                 endpointName: request.endpointName
             )
             connections.insert(connection, at: 0)
         case .disconnected:
-            guard let index = connections.firstIndex(where: { $0.id == endpointID }) else {
+            guard let index = connections.firstIndex(where: { $0.endpointID == endpointID }) else {
                 return
             }
             connections.remove(at: index)
         case .rejected:
-            guard let index = requests.firstIndex(where: { $0.id == endpointID }) else {
+            guard let index = requests.firstIndex(where: { $0.endpointID == endpointID }) else {
                 return
             }
             requests.remove(at: index)


### PR DESCRIPTION
This allows creation of a new instance of the view between separate connections. This will reset view states like disabling a button after a user clicks it.