### PR TITLE
nearby: correctly specify c++17

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,4 @@
-build --action_env=BAZEL_CXXOPTS=-std=c++17
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17
 # Definition of --config=memcheck
 build:memcheck --strip=never --test_timeout=3600


### PR DESCRIPTION
## How did you test this change?
bazel build on mac/linux