### PR TITLE
Fast Pair BLE Device Discovery for Windows in Rust

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -47,6 +47,16 @@ jobs:
         submodules: recursive
     - name: Build FPP
       run:  cargo build --manifest-path presence/fpp/fpp/Cargo.toml
-    - name: Build Fairpair
+    - name: Build Fast Pair
       run:  cargo build --manifest-path fastpair/rust/Cargo.toml
-        
+  
+  build-rust-windows:
+    name: Build Rust on Windows
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Build Fast Pair
+      run:  cargo build --manifest-path fastpair/rust/Cargo.toml
+  

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ Carthage/Build
 .UlyssesRoot
 .Ulysses-Settings.plist
 .Ulysses-Group.plist
+
+# IntelliJ
+.idea
+
+# Rust
+Cargo.lock

--- a/fastpair/rust/.gitignore
+++ b/fastpair/rust/.gitignore
@@ -1,0 +1,2 @@
+# Build files
+target

--- a/fastpair/rust/Cargo.toml
+++ b/fastpair/rust/Cargo.toml
@@ -20,3 +20,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0"
+futures = { version = "0.3", features = ["executor"] }
+tracing = "0.1.37"
+cfg-if = "1.0.0"
+async-trait = "0.1"
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.48", features = [
+    "Devices_Bluetooth",
+    "Devices_Bluetooth_Advertisement",
+    "Foundation",
+] }

--- a/fastpair/rust/rustfmt.toml
+++ b/fastpair/rust/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/fastpair/rust/src/bluetooth/common.rs
+++ b/fastpair/rust/src/bluetooth/common.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
-
 use async_trait::async_trait;
-use futures::stream::Stream;
 
 /// Concrete types implementing this trait are Bluetooth Central devices.
 /// They provide methods for retrieving nearby connections and device info.
@@ -26,14 +23,14 @@ pub trait Adapter: Sized {
     /// Retrieve the system-default Bluetooth adapter.
     async fn default() -> Result<Self, anyhow::Error>;
 
-    /// Scan for nearby devices, returning a `Stream` of futures that can be
-    /// iterated over and polled to retrieve `BleDevice`.
-    //
-    // NOTE: Using Boxed dyn here is silly because in cross-platform code there
-    // should only ever be one concrete type implementing Adapter. Change this
-    // to `impl Stream` once impl trait return types are stabilized in traits.
-    // b/289224233.
-    fn scan_devices(&self) -> Result<Pin<Box<dyn Stream<Item = Self::Device>>>, anyhow::Error>;
+    /// Begin scanning for nearby devices.
+    fn start_scan_devices(&mut self) -> Result<(), anyhow::Error>;
+
+    /// Stop scanning for nearby devices.
+    fn stop_scan_devices(&mut self) -> Result<(), anyhow::Error>;
+
+    /// Poll next discovered device.
+    async fn next_device(&mut self) -> Result<Self::Device, anyhow::Error>;
 }
 
 /// Concrete types implementing this trait represent Bluetooth Peripheral devices.

--- a/fastpair/rust/src/bluetooth/common.rs
+++ b/fastpair/rust/src/bluetooth/common.rs
@@ -1,0 +1,31 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+
+/// Concrete types implementing this trait are Bluetooth Central devices.
+/// They provide methods for retrieving nearby connections and device info.
+#[async_trait]
+pub trait Adapter: Sized {
+    /// Retrieve the system-default Bluetooth adapter.
+    async fn default() -> Result<Self, anyhow::Error>;
+}
+
+/// Concrete types implementing this trait represent Bluetooth Peripheral devices.
+/// They provide methods for retrieving device info and running device actions,
+/// such as pairing.
+pub trait Device {
+    /// Retrieve the name advertised by this device.
+    fn name(&self) -> Result<String, anyhow::Error>;
+}

--- a/fastpair/rust/src/bluetooth/mod.rs
+++ b/fastpair/rust/src/bluetooth/mod.rs
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::executor;
+// Split into separate crate once demo is finished, providing custom error types
+// instead of using anyhow.
+// b/290070686
 
-mod bluetooth;
+pub mod common;
 
-use bluetooth::common::Adapter;
-
-fn main() -> Result<(), anyhow::Error> {
-    let run = async {
-        let _adapter = bluetooth::BleAdapter::default().await?;
-
-        Ok(())
-    };
-
-    executor::block_on(run)
+cfg_if::cfg_if! {
+    if #[cfg(windows)] {
+        mod windows_ble;
+        pub use windows_ble::*;
+    } else {
+        mod unsupported;
+        pub use unsupported::*;
+    }
 }

--- a/fastpair/rust/src/bluetooth/mod.rs
+++ b/fastpair/rust/src/bluetooth/mod.rs
@@ -18,12 +18,18 @@
 
 pub mod common;
 
+pub use common::{Adapter, Device};
+
 cfg_if::cfg_if! {
     if #[cfg(windows)] {
         mod windows_ble;
-        pub use windows_ble::*;
+        use windows_ble::BleAdapter;
     } else {
         mod unsupported;
-        pub use unsupported::*;
+        use unsupported::BleAdapter;
     }
+}
+
+pub async fn default_adapter() -> Result<impl Adapter, anyhow::Error> {
+    BleAdapter::default().await
 }

--- a/fastpair/rust/src/bluetooth/unsupported/adapter.rs
+++ b/fastpair/rust/src/bluetooth/unsupported/adapter.rs
@@ -26,8 +26,17 @@ pub struct BleAdapter;
 
 #[async_trait]
 impl Adapter for BleAdapter {
+    type Device = BleDevice;
+
     async fn default() -> Result<Self, anyhow::Error> {
         panic!("Unsupported target platform.");
+    }
+
+    fn scan_devices(&self) -> Result<Pin<Box<dyn Stream<Item = Self::Device>>>, anyhow::Error> {
+        panic!("Unsupported target platform.");
+        #[allow(unreachable_code)]
+        // Sad satisfying trait bounds github.com/rust-lang/rust/issues/55022.
+        Ok(Box::pin(futures::stream::iter(vec![BleDevice {}])))
     }
 }
 

--- a/fastpair/rust/src/bluetooth/unsupported/adapter.rs
+++ b/fastpair/rust/src/bluetooth/unsupported/adapter.rs
@@ -12,18 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::executor;
+use std::pin::Pin;
 
-mod bluetooth;
+use async_trait::async_trait;
+use futures::stream::Stream;
 
-use bluetooth::common::Adapter;
+use super::BleDevice;
+use crate::bluetooth::common::Adapter;
 
-fn main() -> Result<(), anyhow::Error> {
-    let run = async {
-        let _adapter = bluetooth::BleAdapter::default().await?;
+/// Concrete type implementing `Adapter`, used for unsupported devices.
+/// Every method should panic.
+pub struct BleAdapter;
 
-        Ok(())
-    };
+#[async_trait]
+impl Adapter for BleAdapter {
+    async fn default() -> Result<Self, anyhow::Error> {
+        panic!("Unsupported target platform.");
+    }
+}
 
-    executor::block_on(run)
+mod tests {
+    use super::*;
+
+    // TODO b/288592509 unit tests
 }

--- a/fastpair/rust/src/bluetooth/unsupported/adapter.rs
+++ b/fastpair/rust/src/bluetooth/unsupported/adapter.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
-
 use async_trait::async_trait;
-use futures::stream::Stream;
 
 use super::BleDevice;
 use crate::bluetooth::common::Adapter;
@@ -32,11 +29,16 @@ impl Adapter for BleAdapter {
         panic!("Unsupported target platform.");
     }
 
-    fn scan_devices(&self) -> Result<Pin<Box<dyn Stream<Item = Self::Device>>>, anyhow::Error> {
+    fn start_scan_devices(&mut self) -> Result<(), anyhow::Error> {
         panic!("Unsupported target platform.");
-        #[allow(unreachable_code)]
-        // Sad satisfying trait bounds github.com/rust-lang/rust/issues/55022.
-        Ok(Box::pin(futures::stream::iter(vec![BleDevice {}])))
+    }
+
+    fn stop_scan_devices(&mut self) -> Result<(), anyhow::Error> {
+        panic!("Unsupported target platform.");
+    }
+
+    async fn next_device(&mut self) -> Result<Self::Device, anyhow::Error> {
+        panic!("Unsupported target platform.");
     }
 }
 

--- a/fastpair/rust/src/bluetooth/unsupported/device.rs
+++ b/fastpair/rust/src/bluetooth/unsupported/device.rs
@@ -12,18 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::executor;
+use crate::bluetooth::common::Device;
 
-mod bluetooth;
+/// Concrete type implementing `Device`, used for unsupported devices.
+/// Every method should panic.
+pub struct BleDevice;
 
-use bluetooth::common::Adapter;
+impl Device for BleDevice {
+    fn name(&self) -> Result<String, anyhow::Error> {
+        panic!("Unsupported target platform.")
+    }
+}
 
-fn main() -> Result<(), anyhow::Error> {
-    let run = async {
-        let _adapter = bluetooth::BleAdapter::default().await?;
+mod tests {
+    use super::*;
 
-        Ok(())
-    };
-
-    executor::block_on(run)
+    // TODO b/288592509 unit tests
 }

--- a/fastpair/rust/src/bluetooth/unsupported/mod.rs
+++ b/fastpair/rust/src/bluetooth/unsupported/mod.rs
@@ -12,18 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::executor;
+/// Bluetooth LE module for unsupported devices. Every method panics.
+mod adapter;
+mod device;
 
-mod bluetooth;
-
-use bluetooth::common::Adapter;
-
-fn main() -> Result<(), anyhow::Error> {
-    let run = async {
-        let _adapter = bluetooth::BleAdapter::default().await?;
-
-        Ok(())
-    };
-
-    executor::block_on(run)
-}
+pub use adapter::*;
+pub use device::*;

--- a/fastpair/rust/src/bluetooth/windows_ble/adapter.rs
+++ b/fastpair/rust/src/bluetooth/windows_ble/adapter.rs
@@ -54,7 +54,8 @@ use windows::{
     Foundation::TypedEventHandler,
 };
 
-use crate::bluetooth::{common::Adapter, BleDevice};
+use super::BleDevice;
+use crate::bluetooth::common::Adapter;
 
 /// Concrete type implementing `Adapter`, used for Windows BLE.
 pub struct BleAdapter {
@@ -202,7 +203,7 @@ impl Adapter for BleAdapter {
         }
     }
 
-    async fn next_device(&mut self) -> Result<BleDevice, anyhow::Error> {
+    async fn next_device(&mut self) -> Result<Self::Device, anyhow::Error> {
         if let Some(stream) = &mut self.device_stream {
             stream
                 .next()

--- a/fastpair/rust/src/bluetooth/windows_ble/adapter.rs
+++ b/fastpair/rust/src/bluetooth/windows_ble/adapter.rs
@@ -1,0 +1,49 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use windows::Devices::Bluetooth::BluetoothAdapter;
+
+use crate::bluetooth::common::Adapter;
+
+/// Concrete type implementing `Adapter`, used for Windows BLE.
+pub struct BleAdapter {
+    inner: BluetoothAdapter,
+}
+
+#[async_trait]
+impl Adapter for BleAdapter {
+    async fn default() -> Result<Self, anyhow::Error> {
+        let inner = BluetoothAdapter::GetDefaultAsync()?.await?;
+
+        if !inner.IsLowEnergySupported()? {
+            return Err(anyhow::anyhow!(
+                "This device's Bluetooth Adapter doesn't support Bluetooth LE Transport type."
+            ));
+        }
+        if !inner.IsCentralRoleSupported()? {
+            return Err(anyhow::anyhow!(
+                "This device's Bluetooth Adapter doesn't support Bluetooth LE central role."
+            ));
+        }
+
+        Ok(BleAdapter { inner })
+    }
+}
+
+mod tests {
+    use super::*;
+
+    // TODO b/288592509 unit tests
+}

--- a/fastpair/rust/src/bluetooth/windows_ble/adapter.rs
+++ b/fastpair/rust/src/bluetooth/windows_ble/adapter.rs
@@ -12,10 +12,49 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_trait::async_trait;
-use windows::Devices::Bluetooth::BluetoothAdapter;
+use std::pin::Pin;
+use std::sync::Arc;
 
-use crate::bluetooth::common::Adapter;
+use async_trait::async_trait;
+use futures::{stream::Stream, StreamExt};
+use tracing::{error, warn};
+use windows::{
+    Devices::Bluetooth::{
+        Advertisement::{
+            // Struct that receives Bluetooth Low Energy (LE) advertisements.
+            // https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.advertisement.bluetoothleadvertisementwatcher?view=winrt-22621
+            BluetoothLEAdvertisementReceivedEventArgs,
+
+            // Enum describing the type of advertisement (connectable, directed, etc).
+            // https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothaddresstype?view=winrt-22621
+            BluetoothLEAdvertisementType,
+
+            // Provides data for a Received event on a `BluetoothLEAdvertisementWatcher`.
+            // Instance is created when the Received event occurs in the watcher struct.
+            // https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.advertisement.bluetoothleadvertisementreceivedeventargs?view=winrt-22621
+            BluetoothLEAdvertisementWatcher,
+
+            // Provides data for a Stopped event on a `BluetoothLEAdvertisementWatcher`.
+            // Instance is created when the Stopped event occurs on a watcher struct.
+            // https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.advertisement.bluetoothleadvertisementwatcherstoppedeventargs?view=winrt-22621
+            BluetoothLEAdvertisementWatcherStoppedEventArgs,
+
+            // Defines constants that specify a Bluetooth LE scanning mode.
+            // https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.advertisement.bluetoothlescanningmode?view=winrt-22621
+            BluetoothLEScanningMode,
+        },
+        // Struct for obtaining global constant information about a computer's
+        // Bluetooth adapter.
+        // https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothadapter?view=winrt-22621
+        BluetoothAdapter,
+    },
+    // Wraps a closure for handling events associated with a struct
+    // (e.g. Received and Stopped events in BluetoothLEAdvertisementWatcher).
+    // https://learn.microsoft.com/en-us/uwp/api/windows.foundation.typedeventhandler-2?view=winrt-22621
+    Foundation::TypedEventHandler,
+};
+
+use crate::bluetooth::{common::Adapter, BleDevice};
 
 /// Concrete type implementing `Adapter`, used for Windows BLE.
 pub struct BleAdapter {
@@ -24,6 +63,8 @@ pub struct BleAdapter {
 
 #[async_trait]
 impl Adapter for BleAdapter {
+    type Device = BleDevice;
+
     async fn default() -> Result<Self, anyhow::Error> {
         let inner = BluetoothAdapter::GetDefaultAsync()?.await?;
 
@@ -39,6 +80,98 @@ impl Adapter for BleAdapter {
         }
 
         Ok(BleAdapter { inner })
+    }
+
+    fn scan_devices(&self) -> Result<Pin<Box<dyn Stream<Item = Self::Device>>>, anyhow::Error> {
+        let watcher = BluetoothLEAdvertisementWatcher::new()?;
+        match watcher.SetScanningMode(BluetoothLEScanningMode::Active) {
+            Ok(_) => (),
+            Err(err) => {
+                warn!("Failed to turn on active scanning. Error: {}", err)
+            }
+        };
+
+        if self.inner.IsExtendedAdvertisingSupported()? {
+            watcher.SetAllowExtendedAdvertisements(true)?;
+        }
+
+        // `futures::channel::mpsc` is like `std::sync::mpsc` but `impl Stream`.
+        let (sender, receiver) = futures::channel::mpsc::channel(16);
+        let sender = Arc::new(std::sync::Mutex::new(sender));
+
+        // `received_handler` closure holds non-owning channel reference, to
+        // ensure `stopped_handler` can close the channel when
+        // `received_handler` is done.
+        let weak_sender = Arc::downgrade(&sender);
+        let received_handler = TypedEventHandler::new(
+            // Move `weak_sender` into closure.
+            move |watcher: &Option<BluetoothLEAdvertisementWatcher>,
+                  event_args: &Option<BluetoothLEAdvertisementReceivedEventArgs>| {
+                if watcher.is_some() {
+                    if let Some(event_args) = event_args {
+                        if let Some(sender) = weak_sender.upgrade() {
+                            match sender.lock().unwrap().try_send(event_args.clone()) {
+                                Ok(_) => (),
+                                Err(err) => {
+                                    error!("Error while handling Received event: {:?}", err)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Ok(())
+            },
+        );
+
+        // `stopped_handler` closure owns channel reference, can close channel.
+        let mut sender = Some(sender);
+        let stopped_handler = TypedEventHandler::new(
+            // Move `sender` into closure.
+            move |_watcher,
+                  _event_args: &Option<
+                BluetoothLEAdvertisementWatcherStoppedEventArgs,
+            >| {
+                // Drop `sender`, closing the channel.
+                let _sender = sender.take();
+                println!("Watcher stopped receiving BLE advertisements.");
+                Ok(())
+            },
+        );
+
+        watcher.Received(&received_handler)?;
+        watcher.Stopped(&stopped_handler)?;
+        watcher.Start()?;
+
+        // `receiver` is a `futures::channel::mpsc::Receiver`, which implements
+        // `futures::stream::Stream`. This is essentially an async Iterator.
+        // We apply a FilterMap to map from advertisement packet to a future
+        // returning `BleDevice` and filter out undesired connections. We need a
+        // pinned box to satisfy trait bounds for `Stream`.
+        Ok(Box::pin(receiver.filter_map(move |event_args| {
+            //  Move `watcher` into `FilterMap` closure. This ensures `watcher`
+            // is only dropped when the stream is closed.
+            let _watcher = &watcher;
+
+            // Move `event_args` into async block.
+            async move {
+                match event_args.AdvertisementType().ok()? {
+                    BluetoothLEAdvertisementType::NonConnectableUndirected => None,
+                    _ => {
+                        let addr = event_args.BluetoothAddress().ok()?;
+                        let kind = event_args.BluetoothAddressType().ok()?;
+
+                        match BleDevice::from_addr(addr, kind).await {
+                            Ok(device) => Some(device),
+                            Err(err) => {
+                                warn!("Error creating device: {:?}", err);
+                                None
+                            }
+                        }
+                    }
+                }
+            }
+        })))
     }
 }
 

--- a/fastpair/rust/src/bluetooth/windows_ble/device.rs
+++ b/fastpair/rust/src/bluetooth/windows_ble/device.rs
@@ -12,18 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::executor;
+use windows::Devices::Bluetooth::BluetoothLEDevice;
 
-mod bluetooth;
+use crate::bluetooth::common::Device;
 
-use bluetooth::common::Adapter;
+/// Concrete type implementing `Device`, used for Windows BLE.
+pub struct BleDevice {
+    inner: BluetoothLEDevice,
+}
 
-fn main() -> Result<(), anyhow::Error> {
-    let run = async {
-        let _adapter = bluetooth::BleAdapter::default().await?;
+impl Device for BleDevice {
+    fn name(&self) -> Result<String, anyhow::Error> {
+        Ok(self.inner.Name()?.to_string_lossy())
+    }
+}
 
-        Ok(())
-    };
+mod tests {
 
-    executor::block_on(run)
+    // TODO b/288592509 unit tests
 }

--- a/fastpair/rust/src/bluetooth/windows_ble/mod.rs
+++ b/fastpair/rust/src/bluetooth/windows_ble/mod.rs
@@ -12,18 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::executor;
+/// Bluetooth LE module for Windows devices.
+mod adapter;
+mod device;
 
-mod bluetooth;
-
-use bluetooth::common::Adapter;
-
-fn main() -> Result<(), anyhow::Error> {
-    let run = async {
-        let _adapter = bluetooth::BleAdapter::default().await?;
-
-        Ok(())
-    };
-
-    executor::block_on(run)
-}
+pub use adapter::*;
+pub use device::*;

--- a/fastpair/rust/src/lib.rs
+++ b/fastpair/rust/src/lib.rs
@@ -12,23 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::{executor, StreamExt};
-
-mod bluetooth;
-
-use bluetooth::common::{Adapter, Device};
-
-fn main() -> Result<(), anyhow::Error> {
-    let run = async {
-        let adapter = bluetooth::BleAdapter::default().await?;
-        let mut scanner = adapter.scan_devices()?;
-
-        while let Some(device) = scanner.next().await {
-            println!("found {}", device.name()?)
-        }
-
-        unreachable!("Done scanning");
-    };
-
-    executor::block_on(run)
-}
+/// Library file, exports modules for use in integration tests and external crates.
+pub mod bluetooth;

--- a/fastpair/rust/src/main.rs
+++ b/fastpair/rust/src/main.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::{executor, StreamExt};
+use futures::executor;
 
 mod bluetooth;
 
@@ -20,10 +20,10 @@ use bluetooth::common::{Adapter, Device};
 
 fn main() -> Result<(), anyhow::Error> {
     let run = async {
-        let adapter = bluetooth::BleAdapter::default().await?;
-        let mut scanner = adapter.scan_devices()?;
+        let mut adapter = bluetooth::BleAdapter::default().await?;
+        adapter.start_scan_devices()?;
 
-        while let Some(device) = scanner.next().await {
+        while let Ok(device) = adapter.next_device().await {
             println!("found {}", device.name()?)
         }
 

--- a/fastpair/rust/src/main.rs
+++ b/fastpair/rust/src/main.rs
@@ -16,11 +16,11 @@ use futures::executor;
 
 mod bluetooth;
 
-use bluetooth::common::{Adapter, Device};
+use bluetooth::{Adapter, Device};
 
 fn main() -> Result<(), anyhow::Error> {
     let run = async {
-        let mut adapter = bluetooth::BleAdapter::default().await?;
+        let mut adapter = bluetooth::default_adapter().await?;
         adapter.start_scan_devices()?;
 
         while let Ok(device) = adapter.next_device().await {

--- a/fastpair/rust/tests/integration_test.rs
+++ b/fastpair/rust/tests/integration_test.rs
@@ -12,18 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::executor;
 
-mod bluetooth;
 
-use bluetooth::common::Adapter;
+mod tests {
+    
 
-fn main() -> Result<(), anyhow::Error> {
-    let run = async {
-        let _adapter = bluetooth::BleAdapter::default().await?;
-
-        Ok(())
-    };
-
-    executor::block_on(run)
+    // TODO b/288592509 write integration tests
 }

--- a/fastpair/rust/tests/integration_test.rs
+++ b/fastpair/rust/tests/integration_test.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+use fastpair::*;
 
 mod tests {
-    
+    use super::*;
 
     // TODO b/288592509 write integration tests
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide
  enough information so that others can review your pull request.
-->

## Summary
Implementing Fast Pair BLE Device Discovery for Windows in Rust, as part of intern project. See go/fastpair-seeker-rust for further discussion on design decisions (Design > API Decisions).

## How did you test this change?
This is an in-development prototype, so unit and integration tests will be provided at a later date (b/288592509). 
`cargo run` output for Windows: 
![image (1)](https://github.com/google/nearby/assets/53844396/93872fe6-664e-4866-90e6-e470f225b702)

`cargo run` output for unsupported platform:

![image (2)](https://github.com/google/nearby/assets/53844396/e014f87a-c5de-48d3-b327-8161de0093b1)

