### PR TITLE
Lock flutter_rust_bridge to 1.80.1

### DIFF
--- a/fastpair/rust/demo/rust/Cargo.toml
+++ b/fastpair/rust/demo/rust/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 bluetooth = { version = "0.1", path = "../../bluetooth" }
-flutter_rust_bridge = "1"
+flutter_rust_bridge = "=1.80.1"
 futures = { version = "0.3", features = ["executor"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary
locking crate to prevent build errors

## How did you test this change?
compile
