### PR TITLE
Fix OSS bazel build on MacOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,4 @@
 build --action_env=BAZEL_CXXOPTS=-std=c++17
 # Definition of --config=memcheck
 build:memcheck --strip=never --test_timeout=3600
+build --sandbox_block_path=/usr/local


### PR DESCRIPTION
see https://github.com/bazelbuild/bazel/issues/10472 for more info on why this is needed. Without it, the build will try to use system headers which conflict with project defined headers in this build for boringssl

Tested by building the project on a MacOs machine
