### PR TITLE
Remove pointer-based overload of RandBytes()

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -429,6 +429,7 @@ let package = Package(
         "internal/flags/BUILD",
         "internal/network/BUILD",
         "internal/base/BUILD",
+        "internal/build/BUILD",
         "internal/data/BUILD",
         "internal/test/BUILD",
         // tests

--- a/connections/v3/connections_device.h
+++ b/connections/v3/connections_device.h
@@ -18,9 +18,14 @@
 #include <string>
 #include <vector>
 
-#include "internal/crypto_cros/random.h"
 #include "internal/interop/device.h"
 #include "internal/platform/connection_info.h"
+
+#if NEARBY_CHROMIUM
+#include "crypto/random.h"
+#else
+#include "internal/crypto_cros/random.h"
+#endif
 
 namespace nearby {
 namespace connections {
@@ -59,8 +64,7 @@ class ConnectionsDevice : public nearby::NearbyDevice {
  private:
   std::string GenerateRandomEndpointId() {
     std::string result(kEndpointIdLength, 0);
-    crypto::RandBytes(const_cast<std::string::value_type*>(result.data()),
-                      result.size());
+    crypto::RandBytes(base::as_writable_byte_span(result));
     return result;
   }
 

--- a/fastpair/common/account_key.h
+++ b/fastpair/common/account_key.h
@@ -22,7 +22,13 @@
 #include "absl/strings/escaping.h"
 #include "absl/strings/string_view.h"
 #include "fastpair/common/constant.h"
+#ifdef NEARBY_CHROMIUM
+#include "base/containers/span.h"
+#include "crypto/random.h"
+#else
+#include "internal/base/containers/span.h"
 #include "internal/crypto_cros/random.h"
+#endif
 
 namespace nearby {
 namespace fastpair {
@@ -37,7 +43,7 @@ class AccountKey {
 
   static AccountKey CreateRandomKey() {
     std::string key(kAccountKeySize, 0);
-    ::crypto::RandBytes(key.data(), kAccountKeySize);
+    ::crypto::RandBytes(base::as_writable_byte_span(key));
     return AccountKey(key);
   }
 

--- a/internal/base/BUILD
+++ b/internal/base/BUILD
@@ -42,6 +42,53 @@ cc_library(
 )
 
 cc_library(
+    name = "base_chromium",
+    srcs = [
+    ],
+    hdrs = [
+        "check.h",
+        "check_op.h",
+        "compiler_specific.h",
+        "containers/checked_iterators.h",
+        "containers/dynamic_extent.h",
+        "containers/span.h",
+        "containers/util.h",
+        "memory/raw_ptr_exclusion.h",
+        "types/to_address.h",
+        "numerics/angle_conversions.h",
+        "numerics/basic_ops_impl.h",
+        "numerics/byte_conversions.h",
+        "numerics/checked_math.h",
+        "numerics/checked_math_impl.h",
+        "numerics/clamped_math.h",
+        "numerics/clamped_math_impl.h",
+        "numerics/math_constants.h",
+        "numerics/ostream_operators.h",
+        "numerics/ranges.h",
+        "numerics/safe_conversions_arm_impl.h",
+        "numerics/safe_conversions.h",
+        "numerics/safe_conversions_impl.h",
+        "numerics/safe_math_arm_impl.h",
+        "numerics/safe_math_clang_gcc_impl.h",
+        "numerics/safe_math.h",
+        "numerics/safe_math_shared_impl.h",
+        "numerics/wrapping_math.h",
+    ],
+    copts = [
+        "-Ithird_party",
+    ],
+    visibility = [
+        "//internal/crypto_cros:__pkg__",
+        "//internal/crypto_chromium:__pkg__",
+    ],
+    deps = [
+        "//internal/build:build_chromium",
+        "@com_google_absl//absl/base",
+        "@com_google_absl//absl/log:check",
+    ],
+)
+
+cc_library(
     name = "bluetooth_address",
     srcs = [
         "bluetooth_address.cc",

--- a/internal/base/bluetooth_address.h
+++ b/internal/base/bluetooth_address.h
@@ -15,6 +15,10 @@
 #ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_BLUETOOTH_ADDRESS_H_
 #define THIRD_PARTY_NEARBY_INTERNAL_BASE_BLUETOOTH_ADDRESS_H_
 
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/internal/base/check.h
+++ b/internal/base/check.h
@@ -19,7 +19,12 @@
 #error "Use chromium headers when NEARBY_CHROMIUM is defined."
 #endif
 
+#if defined(NEARBY_SWIFTPM)
+// Redirect to nearby logging.
+#include "third_party/nearby/internal/platform/logging.h"
+#else
 // Redirect to absl logging.
 #include "absl/log/check.h"
+#endif
 
 #endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_CHECK_H_

--- a/internal/base/check.h
+++ b/internal/base/check.h
@@ -12,18 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "internal/crypto_cros/random.h"
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_CHECK_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_CHECK_H_
 
-#include <stddef.h>
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
 
-#include <string>
+// Redirect to absl logging.
+#include "absl/log/check.h"
 
-#include <openssl/rand.h>
-
-namespace crypto {
-
-void RandBytes(base::span<uint8_t> bytes) {
-  RAND_bytes(bytes.data(), bytes.size());
-}
-
-}  // namespace crypto
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_CHECK_H_

--- a/internal/base/check_op.h
+++ b/internal/base/check_op.h
@@ -12,18 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "internal/crypto_cros/random.h"
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_CHECK_OP_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_CHECK_OP_H_
 
-#include <stddef.h>
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
 
-#include <string>
+#include "internal/base/check.h"
 
-#include <openssl/rand.h>
-
-namespace crypto {
-
-void RandBytes(base::span<uint8_t> bytes) {
-  RAND_bytes(bytes.data(), bytes.size());
-}
-
-}  // namespace crypto
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_CHECK_OP_H_

--- a/internal/base/compiler_specific.h
+++ b/internal/base/compiler_specific.h
@@ -1,0 +1,633 @@
+// Copyright 2012 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_COMPILER_SPECIFIC_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_COMPILER_SPECIFIC_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include "internal/build/build_config.h"
+
+#if defined(COMPILER_MSVC) && !defined(__clang__)
+#error "Only clang-cl is supported on Windows, see https://crbug.com/988071"
+#endif
+
+// This is a wrapper around `__has_cpp_attribute`, which can be used to test for
+// the presence of an attribute. In case the compiler does not support this
+// macro it will simply evaluate to 0.
+//
+// References:
+// https://wg21.link/sd6#testing-for-the-presence-of-an-attribute-__has_cpp_attribute
+// https://wg21.link/cpp.cond#:__has_cpp_attribute
+#if defined(__has_cpp_attribute)
+#define HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+#else
+#define HAS_CPP_ATTRIBUTE(x) 0
+#endif
+
+// A wrapper around `__has_attribute`, similar to HAS_CPP_ATTRIBUTE.
+#if defined(__has_attribute)
+#define HAS_ATTRIBUTE(x) __has_attribute(x)
+#else
+#define HAS_ATTRIBUTE(x) 0
+#endif
+
+// A wrapper around `__has_builtin`, similar to HAS_CPP_ATTRIBUTE.
+#if defined(__has_builtin)
+#define HAS_BUILTIN(x) __has_builtin(x)
+#else
+#define HAS_BUILTIN(x) 0
+#endif
+
+// Annotate a function indicating it should not be inlined.
+// Use like:
+//   NOINLINE void DoStuff() { ... }
+#if defined(__clang__) && HAS_ATTRIBUTE(noinline)
+#define NOINLINE [[clang::noinline]]
+#elif defined(COMPILER_GCC) && HAS_ATTRIBUTE(noinline)
+#define NOINLINE __attribute__((noinline))
+#elif defined(COMPILER_MSVC)
+#define NOINLINE __declspec(noinline)
+#else
+#define NOINLINE
+#endif
+
+// Annotate a function indicating it should not be optimized.
+#if defined(__clang__) && HAS_ATTRIBUTE(optnone)
+#define NOOPT [[clang::optnone]]
+#elif defined(COMPILER_GCC) && HAS_ATTRIBUTE(optimize)
+#define NOOPT __attribute__((optimize(0)))
+#else
+#define NOOPT
+#endif
+
+#if defined(__clang__) && defined(NDEBUG) && HAS_ATTRIBUTE(always_inline)
+#define ALWAYS_INLINE [[clang::always_inline]] inline
+#elif defined(COMPILER_GCC) && defined(NDEBUG) && HAS_ATTRIBUTE(always_inline)
+#define ALWAYS_INLINE inline __attribute__((__always_inline__))
+#elif defined(COMPILER_MSVC) && defined(NDEBUG)
+#define ALWAYS_INLINE __forceinline
+#else
+#define ALWAYS_INLINE inline
+#endif
+
+// Annotate a function indicating it should never be tail called. Useful to make
+// sure callers of the annotated function are never omitted from call-stacks.
+// To provide the complementary behavior (prevent the annotated function from
+// being omitted) look at NOINLINE. Also note that this doesn't prevent code
+// folding of multiple identical caller functions into a single signature. To
+// prevent code folding, see NO_CODE_FOLDING() in base/debug/alias.h.
+// Use like:
+//   NOT_TAIL_CALLED void FooBar();
+#if defined(__clang__) && HAS_ATTRIBUTE(not_tail_called)
+#define NOT_TAIL_CALLED [[clang::not_tail_called]]
+#else
+#define NOT_TAIL_CALLED
+#endif
+
+// Specify memory alignment for structs, classes, etc.
+// Use like:
+//   class ALIGNAS(16) MyClass { ... }
+//   ALIGNAS(16) int array[4];
+//
+// In most places you can use the C++11 keyword "alignas", which is preferred.
+//
+// Historically, compilers had trouble mixing __attribute__((...)) syntax with
+// alignas(...) syntax. However, at least Clang is very accepting nowadays. It
+// may be that this macro can be removed entirely.
+#if defined(__clang__)
+#define ALIGNAS(byte_alignment) alignas(byte_alignment)
+#elif defined(COMPILER_MSVC)
+#define ALIGNAS(byte_alignment) __declspec(align(byte_alignment))
+#elif defined(COMPILER_GCC) && HAS_ATTRIBUTE(aligned)
+#define ALIGNAS(byte_alignment) __attribute__((aligned(byte_alignment)))
+#endif
+
+// In case the compiler supports it NO_UNIQUE_ADDRESS evaluates to the C++20
+// attribute [[no_unique_address]]. This allows annotating data members so that
+// they need not have an address distinct from all other non-static data members
+// of its class.
+//
+// References:
+// * https://en.cppreference.com/w/cpp/language/attributes/no_unique_address
+// * https://wg21.link/dcl.attr.nouniqueaddr
+#if defined(COMPILER_MSVC) && HAS_CPP_ATTRIBUTE(msvc::no_unique_address)
+// Unfortunately MSVC ignores [[no_unique_address]] (see
+// https://devblogs.microsoft.com/cppblog/msvc-cpp20-and-the-std-cpp20-switch/#msvc-extensions-and-abi),
+// and clang-cl matches it for ABI compatibility reasons. We need to prefer
+// [[msvc::no_unique_address]] when available if we actually want any effect.
+#define NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#elif HAS_CPP_ATTRIBUTE(no_unique_address)
+#define NO_UNIQUE_ADDRESS [[no_unique_address]]
+#else
+#define NO_UNIQUE_ADDRESS
+#endif
+
+// Tells the compiler a function is using a printf-style format string.
+// |format_param| is the one-based index of the format string parameter;
+// |dots_param| is the one-based index of the "..." parameter.
+// For v*printf functions (which take a va_list), pass 0 for dots_param.
+// (This is undocumented but matches what the system C headers do.)
+// For member functions, the implicit this parameter counts as index 1.
+#if (defined(COMPILER_GCC) || defined(__clang__)) && HAS_ATTRIBUTE(format)
+#define PRINTF_FORMAT(format_param, dots_param) \
+  __attribute__((format(printf, format_param, dots_param)))
+#else
+#define PRINTF_FORMAT(format_param, dots_param)
+#endif
+
+// WPRINTF_FORMAT is the same, but for wide format strings.
+// This doesn't appear to yet be implemented in any compiler.
+// See http://gcc.gnu.org/bugzilla/show_bug.cgi?id=38308 .
+#define WPRINTF_FORMAT(format_param, dots_param)
+// If available, it would look like:
+//   __attribute__((format(wprintf, format_param, dots_param)))
+
+// Sanitizers annotations.
+#if HAS_ATTRIBUTE(no_sanitize)
+#define NO_SANITIZE(what) __attribute__((no_sanitize(what)))
+#endif
+#if !defined(NO_SANITIZE)
+#define NO_SANITIZE(what)
+#endif
+
+// MemorySanitizer annotations.
+#if defined(MEMORY_SANITIZER) && !BUILDFLAG(IS_NACL)
+#include <sanitizer/msan_interface.h>
+
+// Mark a memory region fully initialized.
+// Use this to annotate code that deliberately reads uninitialized data, for
+// example a GC scavenging root set pointers from the stack.
+#define MSAN_UNPOISON(p, size) __msan_unpoison(p, size)
+
+// Check a memory region for initializedness, as if it was being used here.
+// If any bits are uninitialized, crash with an MSan report.
+// Use this to sanitize data which MSan won't be able to track, e.g. before
+// passing data to another process via shared memory.
+#define MSAN_CHECK_MEM_IS_INITIALIZED(p, size) \
+  __msan_check_mem_is_initialized(p, size)
+#else  // MEMORY_SANITIZER
+#define MSAN_UNPOISON(p, size)
+#define MSAN_CHECK_MEM_IS_INITIALIZED(p, size)
+#endif  // MEMORY_SANITIZER
+
+// DISABLE_CFI_PERF -- Disable Control Flow Integrity for perf reasons.
+#if !defined(DISABLE_CFI_PERF)
+#if defined(__clang__) && defined(OFFICIAL_BUILD)
+#define DISABLE_CFI_PERF NO_SANITIZE("cfi")
+#else
+#define DISABLE_CFI_PERF
+#endif
+#endif
+
+// DISABLE_CFI_ICALL -- Disable Control Flow Integrity indirect call checks.
+// Security Note: if you just need to allow calling of dlsym functions use
+// DISABLE_CFI_DLSYM.
+#if !defined(DISABLE_CFI_ICALL)
+#if BUILDFLAG(IS_WIN)
+// Windows also needs __declspec(guard(nocf)).
+#define DISABLE_CFI_ICALL NO_SANITIZE("cfi-icall") __declspec(guard(nocf))
+#else
+#define DISABLE_CFI_ICALL NO_SANITIZE("cfi-icall")
+#endif
+#endif
+#if !defined(DISABLE_CFI_ICALL)
+#define DISABLE_CFI_ICALL
+#endif
+
+// DISABLE_CFI_DLSYM -- applies DISABLE_CFI_ICALL on platforms where dlsym
+// functions must be called. Retains CFI checks on platforms where loaded
+// modules participate in CFI (e.g. Windows).
+#if !defined(DISABLE_CFI_DLSYM)
+#if BUILDFLAG(IS_WIN)
+// Windows modules register functions when loaded so can be checked by CFG.
+#define DISABLE_CFI_DLSYM
+#else
+#define DISABLE_CFI_DLSYM DISABLE_CFI_ICALL
+#endif
+#endif
+#if !defined(DISABLE_CFI_DLSYM)
+#define DISABLE_CFI_DLSYM
+#endif
+
+// Macro useful for writing cross-platform function pointers.
+#if !defined(CDECL)
+#if BUILDFLAG(IS_WIN)
+#define CDECL __cdecl
+#else  // BUILDFLAG(IS_WIN)
+#define CDECL
+#endif  // BUILDFLAG(IS_WIN)
+#endif  // !defined(CDECL)
+
+// Macro for hinting that an expression is likely to be false.
+#if !defined(UNLIKELY)
+#if defined(COMPILER_GCC) || defined(__clang__)
+#define UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#define UNLIKELY(x) (x)
+#endif  // defined(COMPILER_GCC)
+#endif  // !defined(UNLIKELY)
+
+#if !defined(LIKELY)
+#if defined(COMPILER_GCC) || defined(__clang__)
+#define LIKELY(x) __builtin_expect(!!(x), 1)
+#else
+#define LIKELY(x) (x)
+#endif  // defined(COMPILER_GCC)
+#endif  // !defined(LIKELY)
+
+// Compiler feature-detection.
+// clang.llvm.org/docs/LanguageExtensions.html#has-feature-and-has-extension
+#if defined(__has_feature)
+#define HAS_FEATURE(FEATURE) __has_feature(FEATURE)
+#else
+#define HAS_FEATURE(FEATURE) 0
+#endif
+
+#if defined(COMPILER_GCC)
+#define PRETTY_FUNCTION __PRETTY_FUNCTION__
+#elif defined(COMPILER_MSVC)
+#define PRETTY_FUNCTION __FUNCSIG__
+#else
+// See https://en.cppreference.com/w/c/language/function_definition#func
+#define PRETTY_FUNCTION __func__
+#endif
+
+#if !defined(CPU_ARM_NEON)
+#if defined(__arm__)
+#if !defined(__ARMEB__) && !defined(__ARM_EABI__) && !defined(__EABI__) && \
+    !defined(__VFP_FP__) && !defined(_WIN32_WCE) && !defined(ANDROID)
+#error Chromium does not support middle endian architecture
+#endif
+#if defined(__ARM_NEON__)
+#define CPU_ARM_NEON 1
+#endif
+#endif  // defined(__arm__)
+#endif  // !defined(CPU_ARM_NEON)
+
+#if !defined(HAVE_MIPS_MSA_INTRINSICS)
+#if defined(__mips_msa) && defined(__mips_isa_rev) && (__mips_isa_rev >= 5)
+#define HAVE_MIPS_MSA_INTRINSICS 1
+#endif
+#endif
+
+#if defined(__clang__) && HAS_ATTRIBUTE(uninitialized)
+// Attribute "uninitialized" disables -ftrivial-auto-var-init=pattern for
+// the specified variable.
+// Library-wide alternative is
+// 'configs -= [ "//build/config/compiler:default_init_stack_vars" ]' in .gn
+// file.
+//
+// See "init_stack_vars" in build/config/compiler/BUILD.gn and
+// http://crbug.com/977230
+// "init_stack_vars" is enabled for non-official builds and we hope to enable it
+// in official build in 2020 as well. The flag writes fixed pattern into
+// uninitialized parts of all local variables. In rare cases such initialization
+// is undesirable and attribute can be used:
+//   1. Degraded performance
+// In most cases compiler is able to remove additional stores. E.g. if memory is
+// never accessed or properly initialized later. Preserved stores mostly will
+// not affect program performance. However if compiler failed on some
+// performance critical code we can get a visible regression in a benchmark.
+//   2. memset, memcpy calls
+// Compiler may replaces some memory writes with memset or memcpy calls. This is
+// not -ftrivial-auto-var-init specific, but it can happen more likely with the
+// flag. It can be a problem if code is not linked with C run-time library.
+//
+// Note: The flag is security risk mitigation feature. So in future the
+// attribute uses should be avoided when possible. However to enable this
+// mitigation on the most of the code we need to be less strict now and minimize
+// number of exceptions later. So if in doubt feel free to use attribute, but
+// please document the problem for someone who is going to cleanup it later.
+// E.g. platform, bot, benchmark or test name in patch description or next to
+// the attribute.
+#define STACK_UNINITIALIZED [[clang::uninitialized]]
+#else
+#define STACK_UNINITIALIZED
+#endif
+
+// Attribute "no_stack_protector" disables -fstack-protector for the specified
+// function.
+//
+// "stack_protector" is enabled on most POSIX builds. The flag adds a canary
+// to each stack frame, which on function return is checked against a reference
+// canary. If the canaries do not match, it's likely that a stack buffer
+// overflow has occurred, so immediately crashing will prevent exploitation in
+// many cases.
+//
+// In some cases it's desirable to remove this, e.g. on hot functions, or if
+// we have purposely changed the reference canary.
+#if defined(COMPILER_GCC) || defined(__clang__)
+#if HAS_ATTRIBUTE(__no_stack_protector__)
+#define NO_STACK_PROTECTOR __attribute__((__no_stack_protector__))
+#else
+#define NO_STACK_PROTECTOR __attribute__((__optimize__("-fno-stack-protector")))
+#endif
+#else
+#define NO_STACK_PROTECTOR
+#endif
+
+// The ANALYZER_ASSUME_TRUE(bool arg) macro adds compiler-specific hints
+// to Clang which control what code paths are statically analyzed,
+// and is meant to be used in conjunction with assert & assert-like functions.
+// The expression is passed straight through if analysis isn't enabled.
+//
+// ANALYZER_SKIP_THIS_PATH() suppresses static analysis for the current
+// codepath and any other branching codepaths that might follow.
+#if defined(__clang_analyzer__)
+
+inline constexpr bool AnalyzerNoReturn() __attribute__((analyzer_noreturn)) {
+  return false;
+}
+
+inline constexpr bool AnalyzerAssumeTrue(bool arg) {
+  // AnalyzerNoReturn() is invoked and analysis is terminated if |arg| is
+  // false.
+  return arg || AnalyzerNoReturn();
+}
+
+#define ANALYZER_ASSUME_TRUE(arg) ::AnalyzerAssumeTrue(!!(arg))
+#define ANALYZER_SKIP_THIS_PATH() static_cast<void>(::AnalyzerNoReturn())
+
+#else  // !defined(__clang_analyzer__)
+
+#define ANALYZER_ASSUME_TRUE(arg) (arg)
+#define ANALYZER_SKIP_THIS_PATH()
+
+#endif  // defined(__clang_analyzer__)
+
+// Use nomerge attribute to disable optimization of merging multiple same calls.
+#if defined(__clang__) && HAS_ATTRIBUTE(nomerge)
+#define NOMERGE [[clang::nomerge]]
+#else
+#define NOMERGE
+#endif
+
+// Marks a type as being eligible for the "trivial" ABI despite having a
+// non-trivial destructor or copy/move constructor. Such types can be relocated
+// after construction by simply copying their memory, which makes them eligible
+// to be passed in registers. The canonical example is std::unique_ptr.
+//
+// Use with caution; this has some subtle effects on constructor/destructor
+// ordering and will be very incorrect if the type relies on its address
+// remaining constant. When used as a function argument (by value), the value
+// may be constructed in the caller's stack frame, passed in a register, and
+// then used and destructed in the callee's stack frame. A similar thing can
+// occur when values are returned.
+//
+// TRIVIAL_ABI is not needed for types which have a trivial destructor and
+// copy/move constructors, such as base::TimeTicks and other POD.
+//
+// It is also not likely to be effective on types too large to be passed in one
+// or two registers on typical target ABIs.
+//
+// See also:
+//   https://clang.llvm.org/docs/AttributeReference.html#trivial-abi
+//   https://libcxx.llvm.org/docs/DesignDocs/UniquePtrTrivialAbi.html
+#if defined(__clang__) && HAS_ATTRIBUTE(trivial_abi)
+#define TRIVIAL_ABI [[clang::trivial_abi]]
+#else
+#define TRIVIAL_ABI
+#endif
+
+// Detect whether a type is trivially relocatable, ie. a move-and-destroy
+// sequence can replaced with memmove(). This can be used to optimise the
+// implementation of containers. This is automatically true for types that were
+// defined with TRIVIAL_ABI such as scoped_refptr.
+//
+// See also:
+//   https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p1144r8.html
+//   https://clang.llvm.org/docs/LanguageExtensions.html#:~:text=__is_trivially_relocatable
+#if defined(__clang__) && HAS_BUILTIN(__is_trivially_relocatable)
+#define IS_TRIVIALLY_RELOCATABLE(t) __is_trivially_relocatable(t)
+#else
+#define IS_TRIVIALLY_RELOCATABLE(t) false
+#endif
+
+// Marks a member function as reinitializing a moved-from variable.
+// See also
+// https://clang.llvm.org/extra/clang-tidy/checks/bugprone/use-after-move.html#reinitialization
+#if defined(__clang__) && HAS_ATTRIBUTE(reinitializes)
+#define REINITIALIZES_AFTER_MOVE [[clang::reinitializes]]
+#else
+#define REINITIALIZES_AFTER_MOVE
+#endif
+
+#if defined(__clang__)
+#define GSL_OWNER [[gsl::Owner]]
+#define GSL_POINTER [[gsl::Pointer]]
+#else
+#define GSL_OWNER
+#define GSL_POINTER
+#endif
+
+// Adds the "logically_const" tag to a symbol's mangled name. The "Mutable
+// Constants" check [1] detects instances of constants that aren't in .rodata,
+// e.g. due to a missing `const`. Using this tag suppresses the check for this
+// symbol, allowing it to live outside .rodata without a warning.
+//
+// [1]:
+// https://crsrc.org/c/docs/speed/binary_size/android_binary_size_trybot.md#Mutable-Constants
+#if defined(COMPILER_GCC) || defined(__clang__)
+#define LOGICALLY_CONST [[gnu::abi_tag("logically_const")]]
+#else
+#define LOGICALLY_CONST
+#endif
+
+// preserve_most clang's calling convention. Reduces register pressure for the
+// caller and as such can be used for cold calls. Support for the
+// "preserve_most" attribute is limited:
+// - 32-bit platforms do not implement it,
+// - component builds fail because _dl_runtime_resolve() clobbers registers,
+// - there are crashes on arm64 on Windows (https://crbug.com/v8/14065), which
+//   can hopefully be fixed in the future.
+// Additionally, the initial implementation in clang <= 16 overwrote the return
+// register(s) in the epilogue of a preserve_most function, so we only use
+// preserve_most in clang >= 17 (see https://reviews.llvm.org/D143425).
+// Clang only supports preserve_most on X86-64 and AArch64 for now.
+// See https://clang.llvm.org/docs/AttributeReference.html#preserve-most for
+// more details.
+#if (defined(ARCH_CPU_ARM64) || defined(ARCH_CPU_X86_64)) && \
+    !(BUILDFLAG(IS_WIN) && defined(ARCH_CPU_ARM64)) &&       \
+    !defined(COMPONENT_BUILD) && defined(__clang__) &&       \
+    __clang_major__ >= 17 && HAS_ATTRIBUTE(preserve_most)
+#define PRESERVE_MOST __attribute__((preserve_most))
+#else
+#define PRESERVE_MOST
+#endif
+
+// Mark parameters or return types as having a lifetime attached to the class.
+//
+// When used to mark a method's pointer/reference parameter, the compiler is
+// made aware that it will be stored internally in the class and the pointee
+// must outlive the class. Typically used on constructor arguments. It should
+// appear to the right of the parameter's variable name.
+//
+// Example:
+// ```
+// struct S {
+//    S(int* p LIFETIME_BOUND) : ptr_(p) {}
+//
+//    int* ptr_;
+// };
+// ```
+//
+// When used on a method with a return value, the compiler is made aware that
+// the returned type is/has a pointer to the internals of the class, and must
+// not outlive the class object. It should appear after any method qualifiers.
+//
+// Example:
+// ```
+// struct S {
+//   int* GetPtr() const LIFETIME_BOUND { return i_; };
+//
+//   int i_;
+// };
+// ```
+//
+// This allows the compiler to warn in (a limited set of) cases where the
+// pointer would otherwise be left dangling, especially in cases where the
+// pointee would be a destroyed temporary.
+//
+// Docs: https://clang.llvm.org/docs/AttributeReference.html#lifetimebound
+#if defined(__clang__)
+#define LIFETIME_BOUND [[clang::lifetimebound]]
+#else
+#define LIFETIME_BOUND
+#endif
+
+// Mark a function as pure, meaning that it does not have side effects, meaning
+// that it does not write anything external to the function's local variables
+// and return value.
+//
+// WARNING: If this attribute is mis-used it will result in UB and
+// miscompilation, as the optimizator may fold multiple calls into one and
+// reorder them inappropriately. This shouldn't appear outside of key vocabulary
+// types. It allows callers to work with the vocab type directly, and call its
+// methods without having to worry about caching things into local variables in
+// hot code.
+//
+// This attribute must not appear on functions that make use of function
+// pointers, virtual methods, or methods of templates (including operators like
+// comparison), as the "pure" function can not know what those functions do and
+// can not guarantee there will never be sideeffects.
+#if defined(COMPILER_GCC) || defined(__clang__)
+#define PURE_FUNCTION [[gnu::pure]]
+#else
+#define PURE_FUNCTION
+#endif
+
+// Functions should be marked with UNSAFE_BUFFER_USAGE when they lead to
+// out-of-bounds bugs when called with incorrect inputs.
+//
+// Ideally such functions should be paired with a safer version that works with
+// safe primitives like `base::span`. Otherwise, another safer coding pattern
+// should be documented along side the use of `UNSAFE_BUFFER_USAGE`.
+//
+// All functions marked with UNSAFE_BUFFER_USAGE should come with a safety
+// comment that explains the requirements of the function to prevent an
+// out-of-bounds bug. For example:
+// ```
+// // Function to do things between `input` and `end`.
+// //
+// // # Safety
+// // The `input` must point to an array with size at least 5. The `end` must
+// // point within the same allocation of `input` and not come before `input`.
+// ```
+//
+// The requirements described in the safety comment must be sufficient to
+// guarantee that the function never goes out of bounds. Annotating a function
+// in this way means that all callers will be required to wrap the call in an
+// `UNSAFE_BUFFERS()` macro (see below), with a comment justifying how it meets
+// the requirements.
+#if defined(__clang__) && HAS_ATTRIBUTE(unsafe_buffer_usage)
+#define UNSAFE_BUFFER_USAGE [[clang::unsafe_buffer_usage]]
+#else
+#define UNSAFE_BUFFER_USAGE
+#endif
+
+// UNSAFE_BUFFERS() wraps code that violates the -Wunsafe-buffer-usage warning,
+// such as:
+// - pointer arithmetic,
+// - pointer subscripting, and
+// - calls to functions annotated with UNSAFE_BUFFER_USAGE.
+//
+// This indicates code whose bounds correctness cannot be ensured
+// systematically, and thus requires manual review.
+//
+// ** USE OF THIS MACRO SHOULD BE VERY RARE.** This should only be used when
+// strictly necessary. Prefer to use `base::span` instead of pointers, or other
+// safer coding patterns (like std containers) that avoid the opportunity for
+// out-of-bounds bugs to creep into the code. Any use of UNSAFE_BUFFERS() can
+// lead to a critical security bug if any assumptions are wrong, or ever become
+// wrong in the future.
+//
+// The macro should be used to wrap the minimum necessary code, to make it clear
+// what is unsafe, and prevent accidentally opting extra things out of the
+// warning.
+//
+// All usage of UNSAFE_BUFFERS() should come with a `// SAFETY: ...` comment
+// that explains how we have guaranteed that the pointer usage can never go
+// out-of-bounds, or that the requirements of the UNSAFE_BUFFER_USAGE function
+// are met. The safety comment should allow a reader to check that all
+// requirements have been met, using only local invariants. Examples of local
+// invariants include:
+// - Runtime conditions or CHECKs near the UNSAFE_BUFFERS macros
+// - Invariants guaranteed by types in the surrounding code
+// - Invariants guaranteed by function calls in the surrounding code
+// - Caller requirements, if the containing function is itself marked with
+//   UNSAFE_BUFFER_USAGE
+//
+// The last case should be an option of last resort. It is less safe and will
+// require the caller also use the UNSAFE_BUFFERS() macro. Prefer directly
+// capturing such invariants in types like `base::span`.
+//
+// Safety explanations may not rely on invariants that are not fully
+// encapsulated close to the UNSAFE_BUFFERS() usage. Instead, use safer coding
+// patterns or stronger invariants.
+#if defined(__clang__)
+// clang-format off
+// Formatting is off so that we can put each _Pragma on its own line, as
+// recommended by the gcc docs.
+#define UNSAFE_BUFFERS(...)                  \
+  _Pragma("clang unsafe_buffer_usage begin") \
+  __VA_ARGS__                                \
+  _Pragma("clang unsafe_buffer_usage end")
+// clang-format on
+#else
+#define UNSAFE_BUFFERS(...) __VA_ARGS__
+#endif
+
+// Defines a condition for a function to be checked at compile time if the
+// parameter's value is known at compile time. If the condition is failed, the
+// function is omitted from the overload set resolution, much like `requires`.
+//
+// If the parameter is a runtime value, then the condition is unable to be
+// checked and the function will be omitted from the overload set resolution.
+// This ensures the function can only be called with values known at compile
+// time. This is a clang extension.
+//
+// Example:
+// ```
+// void f(int a) ENABLE_IF_ATTR(a > 0) {}
+// f(1);  // Ok.
+// f(0);  // Error: no valid f() found.
+// ```
+//
+// The `ENABLE_IF_ATTR` annotation is preferred over `consteval` with a check
+// that breaks compile because metaprogramming does not observe such checks. So
+// with `consteval`, the function looks callable to concepts/type_traits but is
+// not and will fail to compile even though it reports it's usable. Whereas
+// `ENABLE_IF_ATTR` interacts correctly with metaprogramming. This is especially
+// painful for constructors. See also
+// https://github.com/chromium/subspace/issues/266.
+#if defined(__clang__)
+#define ENABLE_IF_ATTR(cond, msg) __attribute__((enable_if(cond, msg)))
+#else
+#define ENABLE_IF_ATTR(cond, msg)
+#endif
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_COMPILER_SPECIFIC_H_

--- a/internal/base/containers/checked_iterators.h
+++ b/internal/base/containers/checked_iterators.h
@@ -1,0 +1,237 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_CONTAINERS_CHECKED_ITERATORS_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_CONTAINERS_CHECKED_ITERATORS_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include <concepts>
+#include <iterator>
+#include <memory>
+#include <type_traits>
+
+#include "internal/base/check_op.h"
+#include "internal/base/compiler_specific.h"
+#include "internal/base/containers/util.h"
+#include "internal/base/memory/raw_ptr_exclusion.h"
+#include "internal/build/build_config.h"
+
+namespace base {
+
+template <typename T>
+class CheckedContiguousIterator {
+ public:
+  using difference_type = std::ptrdiff_t;
+  using value_type = std::remove_cv_t<T>;
+  using pointer = T*;
+  using reference = T&;
+  using iterator_category = std::contiguous_iterator_tag;
+  using iterator_concept = std::contiguous_iterator_tag;
+
+  // Required for converting constructor below.
+  template <typename U>
+  friend class CheckedContiguousIterator;
+
+  // Required to be able to get to the underlying pointer without triggering
+  // CHECK failures.
+  template <typename Ptr>
+  friend struct std::pointer_traits;
+
+  constexpr CheckedContiguousIterator() = default;
+
+  UNSAFE_BUFFER_USAGE constexpr CheckedContiguousIterator(T* start,
+                                                          const T* end)
+      : CheckedContiguousIterator(start, start, end) {}
+
+  UNSAFE_BUFFER_USAGE constexpr CheckedContiguousIterator(const T* start,
+                                                          T* current,
+                                                          const T* end)
+      : start_(start), current_(current), end_(end) {
+    CHECK_LE(start, current);
+    CHECK_LE(current, end);
+  }
+
+  constexpr CheckedContiguousIterator(const CheckedContiguousIterator& other) =
+      default;
+
+  // Converting constructor allowing conversions like CCI<T> to CCI<const T>,
+  // but disallowing CCI<const T> to CCI<T> or CCI<Derived> to CCI<Base>, which
+  // are unsafe. Furthermore, this is the same condition as used by the
+  // converting constructors of std::span<T> and std::unique_ptr<T[]>.
+  // See https://wg21.link/n4042 for details.
+  template <typename U>
+  constexpr CheckedContiguousIterator(const CheckedContiguousIterator<U>& other)
+    requires(std::convertible_to<U (*)[], T (*)[]>)
+      : start_(other.start_), current_(other.current_), end_(other.end_) {
+    // We explicitly don't delegate to the 3-argument constructor here. Its
+    // CHECKs would be redundant, since we expect |other| to maintain its own
+    // invariant. However, DCHECKs never hurt anybody. Presumably.
+    DCHECK_LE(other.start_, other.current_);
+    DCHECK_LE(other.current_, other.end_);
+  }
+
+  ~CheckedContiguousIterator() = default;
+
+  constexpr CheckedContiguousIterator& operator=(
+      const CheckedContiguousIterator& other) = default;
+
+  friend constexpr bool operator==(const CheckedContiguousIterator& lhs,
+                                   const CheckedContiguousIterator& rhs) {
+    lhs.CheckComparable(rhs);
+    return lhs.current_ == rhs.current_;
+  }
+
+  friend constexpr auto operator<=>(const CheckedContiguousIterator& lhs,
+                                    const CheckedContiguousIterator& rhs) {
+    lhs.CheckComparable(rhs);
+    return lhs.current_ <=> rhs.current_;
+  }
+
+  constexpr CheckedContiguousIterator& operator++() {
+    CHECK_NE(current_, end_);
+    ++current_;
+    return *this;
+  }
+
+  constexpr CheckedContiguousIterator operator++(int) {
+    CheckedContiguousIterator old = *this;
+    ++*this;
+    return old;
+  }
+
+  constexpr CheckedContiguousIterator& operator--() {
+    CHECK_NE(current_, start_);
+    --current_;
+    return *this;
+  }
+
+  constexpr CheckedContiguousIterator operator--(int) {
+    CheckedContiguousIterator old = *this;
+    --*this;
+    return old;
+  }
+
+  constexpr CheckedContiguousIterator& operator+=(difference_type rhs) {
+    if (rhs > 0) {
+      CHECK_LE(rhs, end_ - current_);
+    } else {
+      CHECK_LE(-rhs, current_ - start_);
+    }
+    current_ += rhs;
+    return *this;
+  }
+
+  constexpr CheckedContiguousIterator operator+(difference_type rhs) const {
+    CheckedContiguousIterator it = *this;
+    it += rhs;
+    return it;
+  }
+
+  constexpr friend CheckedContiguousIterator operator+(
+      difference_type lhs,
+      const CheckedContiguousIterator& rhs) {
+    return rhs + lhs;
+  }
+
+  constexpr CheckedContiguousIterator& operator-=(difference_type rhs) {
+    if (rhs < 0) {
+      CHECK_LE(-rhs, end_ - current_);
+    } else {
+      CHECK_LE(rhs, current_ - start_);
+    }
+    current_ -= rhs;
+    return *this;
+  }
+
+  constexpr CheckedContiguousIterator operator-(difference_type rhs) const {
+    CheckedContiguousIterator it = *this;
+    it -= rhs;
+    return it;
+  }
+
+  constexpr friend difference_type operator-(
+      const CheckedContiguousIterator& lhs,
+      const CheckedContiguousIterator& rhs) {
+    lhs.CheckComparable(rhs);
+    return lhs.current_ - rhs.current_;
+  }
+
+  constexpr reference operator*() const {
+    CHECK_NE(current_, end_);
+    return *current_;
+  }
+
+  constexpr pointer operator->() const {
+    CHECK_NE(current_, end_);
+    return current_;
+  }
+
+  constexpr reference operator[](difference_type rhs) const {
+    CHECK_GE(rhs, 0);
+    CHECK_LT(rhs, end_ - current_);
+    return current_[rhs];
+  }
+
+  [[nodiscard]] static bool IsRangeMoveSafe(
+      const CheckedContiguousIterator& from_begin,
+      const CheckedContiguousIterator& from_end,
+      const CheckedContiguousIterator& to) {
+    if (from_end < from_begin)
+      return false;
+    const auto from_begin_uintptr = get_uintptr(from_begin.current_);
+    const auto from_end_uintptr = get_uintptr(from_end.current_);
+    const auto to_begin_uintptr = get_uintptr(to.current_);
+    const auto to_end_uintptr =
+        get_uintptr((to + std::distance(from_begin, from_end)).current_);
+
+    return to_begin_uintptr >= from_end_uintptr ||
+           to_end_uintptr <= from_begin_uintptr;
+  }
+
+ private:
+  constexpr void CheckComparable(const CheckedContiguousIterator& other) const {
+    CHECK_EQ(start_, other.start_);
+    CHECK_EQ(end_, other.end_);
+  }
+
+  // RAW_PTR_EXCLUSION: The embedding class is stack-scoped.
+  RAW_PTR_EXCLUSION const T* start_ = nullptr;
+  RAW_PTR_EXCLUSION T* current_ = nullptr;
+  RAW_PTR_EXCLUSION const T* end_ = nullptr;
+};
+
+template <typename T>
+using CheckedContiguousConstIterator = CheckedContiguousIterator<const T>;
+
+}  // namespace base
+
+// Specialize std::pointer_traits so that we can obtain the underlying raw
+// pointer without resulting in CHECK failures. The important bit is the
+// `to_address(pointer)` overload, which is the standard blessed way to
+// customize `std::to_address(pointer)` in C++20 [1].
+//
+// [1] https://wg21.link/pointer.traits.optmem
+
+template <typename T>
+struct std::pointer_traits<::base::CheckedContiguousIterator<T>> {
+  using pointer = ::base::CheckedContiguousIterator<T>;
+  using element_type = T;
+  using difference_type = ptrdiff_t;
+
+  template <typename U>
+  using rebind = ::base::CheckedContiguousIterator<U>;
+
+  static constexpr pointer pointer_to(element_type& r) noexcept {
+    return pointer(&r, &r);
+  }
+
+  static constexpr element_type* to_address(pointer p) noexcept {
+    return p.current_;
+  }
+};
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_CONTAINERS_CHECKED_ITERATORS_H_

--- a/internal/base/containers/dynamic_extent.h
+++ b/internal/base/containers/dynamic_extent.h
@@ -1,0 +1,22 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_CONTAINERS_DYNAMIC_EXTENT_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_CONTAINERS_DYNAMIC_EXTENT_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include <cstddef>
+#include <limits>
+
+namespace base {
+
+// [views.constants]
+inline constexpr size_t dynamic_extent = std::numeric_limits<size_t>::max();
+
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_CONTAINERS_DYNAMIC_EXTENT_H_

--- a/internal/base/containers/span.h
+++ b/internal/base/containers/span.h
@@ -1,0 +1,1423 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//*** WARNING!!! Do not add more functions and Data types to this file. ***
+// This file needs to be in sync with:
+// https://source.chromium.org/chromium/chromium/src/+/main:base/containers/span.h
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_CONTAINERS_SPAN_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_CONTAINERS_SPAN_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <algorithm>
+#include <array>
+#include <concepts>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <span>
+#include <type_traits>
+#include <utility>
+
+#include "absl/base/attributes.h"
+#include "internal/base/check.h"
+#include "internal/base/compiler_specific.h"
+#include "internal/base/containers/checked_iterators.h"
+#include "internal/base/containers/dynamic_extent.h"
+#include "internal/base/numerics/safe_conversions.h"
+#include "internal/base/types/to_address.h"
+
+namespace base {
+
+template <typename T,
+          size_t Extent = dynamic_extent,
+          typename InternalPtrType = T*>
+class span;
+
+namespace internal {
+
+template <typename From, typename To>
+concept LegalDataConversion =
+    std::convertible_to<std::remove_reference_t<From> (*)[],
+                        std::remove_reference_t<To> (*)[]>;
+
+template <typename T, typename It>
+concept CompatibleIter = std::contiguous_iterator<It> &&
+                         LegalDataConversion<std::iter_reference_t<It>, T>;
+
+template <typename T, typename R>
+concept CompatibleRange =
+    std::ranges::contiguous_range<R> && std::ranges::sized_range<R> &&
+    LegalDataConversion<std::ranges::range_reference_t<R>, T> &&
+    (std::ranges::borrowed_range<R> || std::is_const_v<T>);
+
+template <typename T>
+concept LegacyRangeDataIsPointer = std::is_pointer_v<T>;
+
+template <typename R>
+concept LegacyRange = requires(R& r) {
+  { std::ranges::data(r) } -> LegacyRangeDataIsPointer;
+  { std::ranges::size(r) } -> std::convertible_to<size_t>;
+};
+
+// NOTE: Ideally we'd just use `CompatibleRange`, however this currently breaks
+// code that was written prior to C++20 being standardized and assumes providing
+// .data() and .size() is sufficient.
+// TODO: https://crbug.com/1504998 - Remove in favor of CompatibleRange and fix
+// callsites.
+template <typename T, typename R>
+concept LegacyCompatibleRange = LegacyRange<R> && requires(R& r) {
+  { *std::ranges::data(r) } -> LegalDataConversion<T>;
+};
+
+template <size_t I>
+using size_constant = std::integral_constant<size_t, I>;
+
+template <typename T>
+struct ExtentImpl : size_constant<dynamic_extent> {};
+
+template <typename T, size_t N>
+struct ExtentImpl<T[N]> : size_constant<N> {};
+
+template <typename T, size_t N>
+struct ExtentImpl<std::array<T, N>> : size_constant<N> {};
+
+template <typename T, size_t N>
+struct ExtentImpl<base::span<T, N>> : size_constant<N> {};
+
+template <typename T>
+using Extent = ExtentImpl<std::remove_cvref_t<T>>;
+
+template <typename T>
+inline constexpr size_t ExtentV = Extent<T>::value;
+
+// must_not_be_dynamic_extent prevents |dynamic_extent| from being returned in a
+// constexpr context.
+template <size_t kExtent>
+constexpr size_t must_not_be_dynamic_extent() {
+  static_assert(
+      kExtent != dynamic_extent,
+      "EXTENT should only be used for containers with a static extent.");
+  return kExtent;
+}
+
+template <class T, class U, size_t N, size_t M>
+  requires((N == M || N == dynamic_extent || M == dynamic_extent) &&
+           std::equality_comparable_with<T, U>)
+constexpr bool span_cmp(span<T, N> l, span<U, M> r);
+
+}  // namespace internal
+
+// A span is a value type that represents an array of elements of type T. Since
+// it only consists of a pointer to memory with an associated size, it is very
+// light-weight. It is cheap to construct, copy, move and use spans, so that
+// users are encouraged to use it as a pass-by-value parameter. A span does not
+// own the underlying memory, so care must be taken to ensure that a span does
+// not outlive the backing store.
+//
+// span is somewhat analogous to std::string_view, but with arbitrary element
+// types, allowing mutation if T is non-const.
+//
+// span is implicitly convertible from C++ arrays, as well as most [1]
+// container-like types that provide a data() and size() method (such as
+// std::vector<T>). A mutable span<T> can also be implicitly converted to an
+// immutable span<const T>.
+//
+// Consider using a span for functions that take a data pointer and size
+// parameter: it allows the function to still act on an array-like type, while
+// allowing the caller code to be a bit more concise.
+//
+// For read-only data access pass a span<const T>: the caller can supply either
+// a span<const T> or a span<T>, while the callee will have a read-only view.
+// For read-write access a mutable span<T> is required.
+//
+// Without span:
+//   Read-Only:
+//     // std::string HexEncode(const uint8_t* data, size_t size);
+//     std::vector<uint8_t> data_buffer = GenerateData();
+//     std::string r = HexEncode(data_buffer.data(), data_buffer.size());
+//
+//  Mutable:
+//     // ssize_t SafeSNPrintf(char* buf, size_t N, const char* fmt, Args...);
+//     char str_buffer[100];
+//     SafeSNPrintf(str_buffer, sizeof(str_buffer), "Pi ~= %lf", 3.14);
+//
+// With span:
+//   Read-Only:
+//     // std::string HexEncode(base::span<const uint8_t> data);
+//     std::vector<uint8_t> data_buffer = GenerateData();
+//     std::string r = HexEncode(data_buffer);
+//
+//  Mutable:
+//     // ssize_t SafeSNPrintf(base::span<char>, const char* fmt, Args...);
+//     char str_buffer[100];
+//     SafeSNPrintf(str_buffer, "Pi ~= %lf", 3.14);
+//
+// Dynamic vs Fixed size spans
+// ---------------------------
+//
+// Normally spans have a dynamic size, which is represented as a type as
+// `span<T>`. However it is possible to encode the size of the span into the
+// type as a second parameter such as `span<T, N>`. When working with fixed-size
+// spans, the compiler will check the size of operations and prevent compilation
+// when an invalid size is used for an operation such as assignment or
+// `copy_from()`. However operations that produce a new span will make a
+// dynamic-sized span by default. See below for how to prevent that.
+//
+// Fixed-size spans implicitly convert to a dynamic-size span, throwing away the
+// compile-time size information from the type signature. So most code should
+// work with dynamic-sized `span<T>` types and not worry about the existence of
+// fixed-size spans.
+//
+// It is possible to convert from a dynamic-size to a fixed-size span (or to
+// move from a fixed-size span to another fixed-size span) but it requires
+// writing an the size explicitly in the code. Methods like `first` can be
+// passed a size as a template argument, such as `first<N>()` to generate a
+// fixed-size span. And the `make_span` function can be given a compile-time
+// size in a similar way with `make_span<N>()`.
+//
+// Spans with "const" and pointers
+// -------------------------------
+//
+// Const and pointers can get confusing. Here are vectors of pointers and their
+// corresponding spans:
+//
+//   const std::vector<int*>        =>  base::span<int* const>
+//   std::vector<const int*>        =>  base::span<const int*>
+//   const std::vector<const int*>  =>  base::span<const int* const>
+//
+// Differences from the C++ standard
+// ---------------------------------
+//
+// http://eel.is/c++draft/views.span contains the latest C++ draft of std::span.
+// Chromium tries to follow the draft as close as possible. Differences between
+// the draft and the implementation are documented in subsections below.
+//
+// Differences from [span.overview]:
+// - Dynamic spans are implemented as a partial specialization of the regular
+//   class template. This leads to significantly simpler checks involving the
+//   extent, at the expense of some duplicated code. The same strategy is used
+//   by libc++.
+//
+// Differences from [span.objectrep]:
+// - as_bytes() and as_writable_bytes() return spans of uint8_t instead of
+//   std::byte.
+//
+// Differences from [span.cons]:
+// - The constructors from a contiguous range apart from a C array are folded
+//   into a single one, using a construct similarly to the one proposed
+//   (but not standardized) in https://wg21.link/P1419.
+//   The C array constructor is kept so that a span can be constructed from
+//   an init list like {{1, 2, 3}}.
+//   TODO: https://crbug.com/828324 - Consider adding C++26's constructor from
+//   a std::initializer_list instead.
+// - The conversion constructors from a contiguous range into a dynamic span
+//   don't check for the range concept, but rather whether std::ranges::data
+//   and std::ranges::size are well formed. This is due to legacy reasons and
+//   should be fixed.
+//
+// Differences from [span.deduct]:
+// - The deduction guides from a contiguous range are folded into a single one,
+//   and treat borrowed ranges correctly.
+// - Add deduction guide from rvalue array.
+//
+// Other differences:
+// - Using StrictNumeric<size_t> instead of size_t where possible.
+//
+// Additions beyond the C++ standard draft
+// - as_chars() function.
+// - as_writable_chars() function.
+// - as_byte_span() function.
+// - as_writable_byte_span() function.
+// - copy_from() method.
+// - span_from_ref() function.
+// - byte_span_from_ref() function.
+// - span_from_cstring() function.
+// - byte_span_from_cstring() function.
+// - split_at() method.
+// - operator==() comparator function.
+//
+// Furthermore, all constructors and methods are marked noexcept due to the lack
+// of exceptions in Chromium.
+//
+// Due to the lack of class template argument deduction guides in C++14
+// appropriate make_span() utility functions are provided for historic reasons.
+
+// [span], class template span
+template <typename T, size_t N, typename InternalPtrType>
+class GSL_POINTER span {
+ public:
+  using element_type = T;
+  using value_type = std::remove_cv_t<T>;
+  using size_type = size_t;
+  using difference_type = ptrdiff_t;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using reference = T&;
+  using const_reference = const T&;
+  using iterator = CheckedContiguousIterator<T>;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  static constexpr size_t extent = N;
+
+  // [span.cons], span constructors, copy, assignment, and destructor
+  constexpr span() noexcept
+    requires(N == 0)
+  = default;
+
+  // Constructs a span from a contiguous iterator and a size.
+  //
+  // # Checks
+  // The function CHECKs that `count` matches the template parameter `N` and
+  // will terminate otherwise.
+  //
+  // # Safety
+  // The iterator must point to the first of at least `count` many elements, or
+  // Undefined Behaviour can result as the span will allow access beyond the
+  // valid range of the collection pointed to by the iterator.
+  template <typename It>
+    requires(internal::CompatibleIter<T, It>)
+  UNSAFE_BUFFER_USAGE explicit constexpr span(
+      It first,
+      StrictNumeric<size_t> count) noexcept
+      :  // The use of to_address() here is to handle the case where the
+         // iterator `first` is pointing to the container's `end()`. In that
+         // case we can not use the address returned from the iterator, or
+         // dereference it through the iterator's `operator*`, but we can store
+         // it. We must assume in this case that `count` is 0, since the
+         // iterator does not point to valid data. Future hardening of iterators
+         // may disallow pulling the address from `end()`, as demonstrated by
+         // asserts() in libstdc++:
+         // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93960.
+         //
+         // The span API dictates that the `data()` is accessible when size is
+         // 0, since the pointer may be valid, so we cannot prevent storing and
+         // giving out an invalid pointer here without breaking API
+         // compatibility and our unit tests. Thus protecting against this can
+         // likely only be successful from inside iterators themselves, where
+         // the context about the pointer is known.
+         //
+         // We can not protect here generally against an invalid iterator/count
+         // being passed in, since we have no context to determine if the
+         // iterator or count are valid.
+        data_(base::to_address(first)) {
+    // Guarantees that the N in the type signature is correct.
+    CHECK(N == count);
+  }
+
+  // Constructs a span from a contiguous iterator and a size.
+  //
+  // # Checks
+  // The function CHECKs that `it <= end` and will terminate otherwise.
+  //
+  // # Safety
+  // The begin and end iterators must be for the same allocation or Undefined
+  // Behaviour can result as the span will allow access beyond the valid range
+  // of the collection pointed to by `begin`.
+  template <typename It, typename End>
+    requires(internal::CompatibleIter<T, It> &&
+             std::sized_sentinel_for<End, It> &&
+             !std::convertible_to<End, size_t>)
+  UNSAFE_BUFFER_USAGE explicit constexpr span(It begin, End end) noexcept
+      // SAFETY: The caller must guarantee that the iterator and end sentinel
+      // are part of the same allocation, in which case it is the number of
+      // elements between the iterators and thus a valid size for the pointer to
+      // the element at `begin`.
+      //
+      // We CHECK that `end - begin` did not underflow below. Normally checking
+      // correctness afterward is flawed, however underflow is not UB and the
+      // size is not converted to an invalid pointer (which would be UB) before
+      // we CHECK for underflow.
+      : UNSAFE_BUFFERS(span(begin, static_cast<size_t>(end - begin))) {
+    // Verify `end - begin` did not underflow.
+    CHECK(begin <= end);
+  }
+
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr span(T (&arr)[N]) noexcept
+      // SAFETY: The std::ranges::size() function gives the number of elements
+      // pointed to by the std::ranges::data() function, which meets the
+      // requirement of span.
+      : UNSAFE_BUFFERS(span(std::ranges::data(arr), std::ranges::size(arr))) {}
+
+  template <typename R, size_t X = internal::ExtentV<R>>
+    requires(internal::CompatibleRange<T, R> && (X == N || X == dynamic_extent))
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  explicit(X == dynamic_extent) constexpr span(R&& range) noexcept
+      // SAFETY: The std::ranges::size() function gives the number of elements
+      // pointed to by the std::ranges::data() function, which meets the
+      // requirement of span.
+      : UNSAFE_BUFFERS(
+            span(std::ranges::data(range), std::ranges::size(range))) {}
+
+  // [span.sub], span subviews
+  template <size_t Count>
+  constexpr span<T, Count> first() const noexcept
+    requires(Count <= N)
+  {
+    // SAFETY: span provides that data() points to at least `N` many elements.
+    // `Count` is non-negative by its type and `Count <= N` from the requires
+    // condition. So `Count` is a valid new size for `data()`.
+    return UNSAFE_BUFFERS(span<T, Count>(data(), Count));
+  }
+
+  template <size_t Count>
+  constexpr span<T, Count> last() const noexcept
+    requires(Count <= N)
+  {
+    // SAFETY: span provides that data() points to at least `N` many elements.
+    // `Count` is non-negative by its type and `Count <= N` from the requires
+    // condition. So `0 <= N - Count <= N`, meaning `N - Count` is a valid new
+    // size for `data()` and it will point to `Count` many elements.`
+    return UNSAFE_BUFFERS(span<T, Count>(data() + (N - Count), Count));
+  }
+
+  // Returns a span over the first `count` elements.
+  //
+  // # Checks
+  // The function CHECKs that the span contains at least `count` elements and
+  // will terminate otherwise.
+  constexpr span<T> first(StrictNumeric<size_t> count) const noexcept {
+    CHECK_LE(size_t{count}, size());
+    // SAFETY: span provides that data() points to at least `N` many elements.
+    // `count` is non-negative by its type and `count <= N` from the CHECK
+    // above. So `count` is a valid new size for `data()`.
+    return UNSAFE_BUFFERS({data(), count});
+  }
+
+  // Returns a span over the last `count` elements.
+  //
+  // # Checks
+  // The function CHECKs that the span contains at least `count` elements and
+  // will terminate otherwise.
+  constexpr span<T> last(StrictNumeric<size_t> count) const noexcept {
+    CHECK_LE(size_t{count}, N);
+    // SAFETY: span provides that data() points to at least `N` many elements.
+    // `count` is non-negative by its type and `count <= N` from the CHECK
+    // above. So `0 <= N - count <= N`, meaning `N - count` is a valid new size
+    // for `data()` and it will point to `count` many elements.
+    return UNSAFE_BUFFERS({data() + (N - size_t{count}), count});
+  }
+
+  template <size_t Offset, size_t Count = dynamic_extent>
+  constexpr auto subspan() const noexcept
+    requires(Offset <= N && (Count == dynamic_extent || Count <= N - Offset))
+  {
+    constexpr size_t kExtent = Count != dynamic_extent ? Count : N - Offset;
+    // SAFETY: span provides that data() points to at least `N` many elements.
+    //
+    // If Count is dynamic_extent, kExtent becomes `N - Offset`. Since `Offset
+    // <= N` from the requires condition, then `Offset` is a valid offset for
+    // data(), and `Offset + kExtent = Offset + N - Offset = N >= Offset` is
+    // also a valid offset that is not before `Offset`. This makes a span at
+    // `Offset` with size `kExtent` valid.
+    //
+    // Otherwise `Count <= N - Offset` and `0 <= Offset <= N` by the requires
+    // condition, so `Offset <= N - Count` and `N - Count` can not underflow.
+    // Then `Offset` is a valid offset for data() and `kExtent` is `Count <= N -
+    // Offset`, so `Offset + kExtent <= Offset + N - Offset = N` which makes
+    // both `Offset` and `Offset + kExtent` valid offsets for data(), and since
+    // `kExtent` is non-negative, `Offset + kExtent` is not before `Offset` so
+    // `kExtent` is a valid size for the span at `data() + Offset`.
+    return UNSAFE_BUFFERS(span<T, kExtent>(data() + Offset, kExtent));
+  }
+
+  // Returns a span over the first `count` elements starting at the given
+  // `offset` from the start of the span.
+  //
+  // # Checks
+  // The function CHECKs that the span contains at least `offset + count`
+  // elements, or at least `offset` elements if `count` is not specified, and
+  // will terminate otherwise.
+  constexpr span<T> subspan(size_t offset,
+                            size_t count = dynamic_extent) const noexcept {
+    CHECK_LE(offset, N);
+    CHECK(count == dynamic_extent || count <= N - offset);
+    const size_t new_extent = count != dynamic_extent ? count : N - offset;
+    // SAFETY: span provides that data() points to at least `N` many elements.
+    //
+    // If Count is dynamic_extent, `new_extent` becomes `N - offset`. Since
+    // `offset <= N` from the requires condition, then `offset` is a valid
+    // offset for data(), and `offset + new_extent = offset + N - offset = N >=
+    // offset` is also a valid offset that is not before `offset`. This makes a
+    // span at `offset` with size `new_extent` valid.
+    //
+    // Otherwise `count <= N - offset` and `0 <= offset <= N` by the requires
+    // condition, so `offset <= N - count` and `N - count` can not underflow.
+    // Then `offset` is a valid offset for data() and `new_extent` is `count <=
+    // N - offset`, so `offset + new_extent <= offset + N - offset = N` which
+    // makes both `offset` and `offset + new_extent` valid offsets for data(),
+    // and since `new_extent` is non-negative, `offset + new_extent` is not
+    // before `offset` so `new_extent` is a valid size for the span at `data() +
+    // offset`.
+    return UNSAFE_BUFFERS({data() + offset, new_extent});
+  }
+
+  // Splits a span into two at the given `offset`, returning two spans that
+  // cover the full range of the original span.
+  //
+  // Similar to calling subspan() with the `offset` as the length on the first
+  // call, and then the `offset` as the offset in the second.
+  //
+  // The split_at<N>() overload allows construction of a fixed-size span from a
+  // compile-time constant. If the input span is fixed-size, both output output
+  // spans will be. Otherwise, the first will be fixed-size and the second will
+  // be dynamic-size.
+  //
+  // This is a non-std extension that  is inspired by the Rust slice::split_at()
+  // and split_at_mut() methods.
+  //
+  // # Checks
+  // The function CHECKs that the span contains at least `offset` elements and
+  // will terminate otherwise.
+  constexpr std::pair<span<T>, span<T>> split_at(size_t offset) const noexcept {
+    return {first(offset), subspan(offset)};
+  }
+
+  template <size_t Offset>
+    requires(Offset <= N)
+  constexpr std::pair<span<T, Offset>, span<T, N - Offset>> split_at()
+      const noexcept {
+    return {first<Offset>(), subspan<Offset, N - Offset>()};
+  }
+
+  // [span.obs], span observers
+  constexpr size_t size() const noexcept { return N; }
+  constexpr size_t size_bytes() const noexcept { return size() * sizeof(T); }
+  [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0; }
+
+  // [span.elem], span element access
+  //
+  // # Checks
+  // The function CHECKs that the `idx` is inside the span and will terminate
+  // otherwise.
+  constexpr T& operator[](size_t idx) const noexcept {
+    CHECK_LT(idx, size());
+    // SAFETY: Since data() always points to at least `N` elements, the check
+    // above ensures `idx < N` and is thus in range for data().
+    return UNSAFE_BUFFERS(data()[idx]);
+  }
+
+  constexpr T& front() const noexcept
+    requires(N > 0)
+  {
+    // SAFETY: Since data() always points to at least `N` elements, the requires
+    // constraint above ensures `0 < N` and is thus in range for data().
+    return UNSAFE_BUFFERS(data()[0]);
+  }
+
+  constexpr T& back() const noexcept
+    requires(N > 0)
+  {
+    // SAFETY: Since data() always points to at least `N` elements, the requires
+    // constraint above ensures `N > 0` and thus `N - 1` does not underflow and
+    // is in range for data().
+    return UNSAFE_BUFFERS(data()[N - 1]);
+  }
+
+  // Returns a pointer to the first element in the span. If the span is empty
+  // (`size()` is 0), the returned pointer may or may not be null, and it must
+  // not be dereferenced.
+  //
+  // It is always valid to add `size()` to the the pointer in C++ code, though
+  // it may be invalid in C code when the span is empty.
+  constexpr T* data() const noexcept { return data_; }
+
+  // [span.iter], span iterator support
+  constexpr iterator begin() const noexcept {
+    // SAFETY: span provides that data() points to at least `size()` many
+    // elements, and size() is non-negative. So data() + size() is a valid
+    // pointer for the data() allocation.
+    return UNSAFE_BUFFERS(iterator(data(), data() + size()));
+  }
+
+  constexpr iterator end() const noexcept {
+    // SAFETY: span provides that data() points to at least `size()` many
+    // elements, and size() is non-negative. So data() + size() is a valid
+    // pointer for the data() allocation.
+    return UNSAFE_BUFFERS(iterator(data(), data() + size(), data() + size()));
+  }
+
+  constexpr reverse_iterator rbegin() const noexcept {
+    return reverse_iterator(end());
+  }
+
+  constexpr reverse_iterator rend() const noexcept {
+    return reverse_iterator(begin());
+  }
+
+  // Bounds-checked copy from a non-overlapping span. The spans must be the
+  // exact same size or a hard CHECK() occurs. If the two spans overlap,
+  // Undefined Behaviour occurs.
+  //
+  // This is a non-std extension that is inspired by the Rust
+  // slice::copy_from_slice() method.
+  //
+  // # Checks
+  // The function CHECKs that the `other` span has the same size as itself and
+  // will terminate otherwise.
+  constexpr void copy_from(span<const T, N> other)
+    requires(!std::is_const_v<T>)
+  {
+    CHECK_EQ(size_bytes(), other.size_bytes());
+    // Verify non-overlapping in developer builds.
+    //
+    // SAFETY: span provides that data() points to at least size() many
+    // elements, so adding size() to the data() pointer is well-defined.
+    DCHECK(UNSAFE_BUFFERS(data() + size()) <= other.data() ||
+           data() >= UNSAFE_BUFFERS(other.data() + other.size()));
+    // When compiling with -Oz, std::ranges::copy() does not get inlined, which
+    // makes copy_from() very expensive compared to memcpy for small sizes (up
+    // to around 4x slower). We observe that this is because ranges::copy() uses
+    // begin()/end() and span's iterators are checked iterators, not just
+    // pointers. This additional complexity prevents inlining and breaks the
+    // ability for the compiler to eliminate code.
+    //
+    // See also https://crbug.com/1396134.
+    //
+    // We also see std::copy() (with pointer arguments! not iterators) optimize
+    // and inline better than memcpy() since memcpy() needs to rely on
+    // size_bytes(), which while computable at compile time when `other` has a
+    // fixed size, the optimizer stumbles on with -Oz.
+    //
+    // SAFETY: The copy() here does not check bounds, but we have verified that
+    // `this` and `other` have the same bounds above (and are pointers of the
+    // same type), so `data()` and `other.data()` both have at least
+    // `other.size()` elements.
+    UNSAFE_BUFFERS(
+        std::copy(other.data(), other.data() + other.size(), data()));
+  }
+
+  // Implicit conversion from std::span<T, N> to base::span<T, N>.
+  //
+  // We get other conversions for free from std::span's constructors, but it
+  // does not deduce N on its range constructor.
+  span(std::span<std::remove_const_t<T>, N> other)
+      :  // SAFETY: std::span contains a valid data pointer and size such
+         // that pointer+size remains valid.
+        UNSAFE_BUFFERS(
+            span(std::ranges::data(other), std::ranges::size(other))) {}
+  span(std::span<T, N> other)
+    requires(std::is_const_v<T>)
+      :  // SAFETY: std::span contains a valid data pointer and size such
+         // that pointer+size remains valid.
+        UNSAFE_BUFFERS(
+            span(std::ranges::data(other), std::ranges::size(other))) {}
+
+  // Implicit conversion from base::span<T, N> to std::span<T, N>.
+  //
+  // We get other conversions for free from std::span's constructors, but it
+  // does not deduce N on its range constructor.
+  operator std::span<T, N>() const { return std::span<T, N>(*this); }
+  operator std::span<const T, N>() const
+    requires(!std::is_const_v<T>)
+  {
+    return std::span<const T, N>(*this);
+  }
+
+  // Compares two spans for equality by comparing the objects pointed to by the
+  // spans. The operation is defined for spans of different types as long as the
+  // types are themselves comparable.
+  //
+  // For primitive types, this replaces the less safe `memcmp` function, where
+  // `memcmp(a.data(), b.data(), a.size())` can be written as `a == b` and can
+  // no longer go outside the bounds of `b`. Otherwise, it replaced std::equal
+  // or std::ranges::equal when working with spans, and when no projection is
+  // needed.
+  //
+  // If the spans are of different sizes, they are not equal. If both spans are
+  // empty, they are always equal (even though their data pointers may differ).
+  //
+  // # Implementation note
+  // The non-template overloads allow implicit conversions to span for
+  // comparison.
+  friend constexpr bool operator==(span lhs, span rhs)
+    requires(std::equality_comparable<const T>)
+  {
+    return internal::span_cmp(span<const T, N>(lhs), span<const T, N>(rhs));
+  }
+  friend constexpr bool operator==(span lhs, span<const T, N> rhs)
+    requires(!std::is_const_v<T> && std::equality_comparable<const T>)
+  {
+    return internal::span_cmp(span<const T, N>(lhs), span<const T, N>(rhs));
+  }
+  template <class U, size_t M>
+    requires((N == M || M == dynamic_extent) &&
+             std::equality_comparable_with<const T, const U>)
+  friend constexpr bool operator==(span lhs, span<U, M> rhs) {
+    return internal::span_cmp(span<const T, N>(lhs), span<const U, M>(rhs));
+  }
+
+ private:
+  // This field is not a raw_ptr<> since span is mostly used for stack
+  // variables. Use `raw_span` instead for class fields, which does use
+  // raw_ptr<> internally.
+  InternalPtrType data_ = nullptr;
+};
+
+// [span], class template span
+template <typename T, typename InternalPtrType>
+class GSL_POINTER span<T, dynamic_extent, InternalPtrType> {
+ public:
+  using element_type = T;
+  using value_type = std::remove_cv_t<T>;
+  using size_type = size_t;
+  using difference_type = ptrdiff_t;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using reference = T&;
+  using const_reference = const T&;
+  using iterator = CheckedContiguousIterator<T>;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  static constexpr size_t extent = dynamic_extent;
+
+  constexpr span() noexcept = default;
+
+  // Constructs a span from a contiguous iterator and a size.
+  //
+  // # Safety
+  // The iterator must point to the first of at least `count` many elements, or
+  // Undefined Behaviour can result as the span will allow access beyond the
+  // valid range of the collection pointed to by the iterator.
+  template <typename It>
+    requires(internal::CompatibleIter<T, It>)
+  UNSAFE_BUFFER_USAGE constexpr span(It first,
+                                     StrictNumeric<size_t> count) noexcept
+      // The use of to_address() here is to handle the case where the iterator
+      // `first` is pointing to the container's `end()`. In that case we can
+      // not use the address returned from the iterator, or dereference it
+      // through the iterator's `operator*`, but we can store it. We must
+      // assume in this case that `count` is 0, since the iterator does not
+      // point to valid data. Future hardening of iterators may disallow
+      // pulling the address from `end()`, as demonstrated by asserts() in
+      // libstdc++: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93960.
+      //
+      // The span API dictates that the `data()` is accessible when size is 0,
+      // since the pointer may be valid, so we cannot prevent storing and
+      // giving out an invalid pointer here without breaking API compatibility
+      // and our unit tests. Thus protecting against this can likely only be
+      // successful from inside iterators themselves, where the context about
+      // the pointer is known.
+      //
+      // We can not protect here generally against an invalid iterator/count
+      // being passed in, since we have no context to determine if the
+      // iterator or count are valid.
+      : data_(base::to_address(first)), size_(count) {}
+
+  // Constructs a span from a contiguous iterator and a size.
+  //
+  // # Safety
+  // The begin and end iterators must be for the same allocation, and `begin <=
+  // end` or Undefined Behaviour can result as the span will allow access beyond
+  // the valid range of the collection pointed to by `begin`.
+  template <typename It, typename End>
+    requires(internal::CompatibleIter<T, It> &&
+             std::sized_sentinel_for<End, It> &&
+             !std::convertible_to<End, size_t>)
+  UNSAFE_BUFFER_USAGE constexpr span(It begin, End end) noexcept
+      // SAFETY: The caller must guarantee that the iterator and end sentinel
+      // are part of the same allocation, in which case it is the number of
+      // elements between the iterators and thus a valid size for the pointer to
+      // the element at `begin`.
+      //
+      // We CHECK that `end - begin` did not underflow below. Normally checking
+      // correctness afterward is flawed, however underflow is not UB and the
+      // size is not converted to an invalid pointer (which would be UB) before
+      // we CHECK for underflow.
+      : UNSAFE_BUFFERS(span(begin, static_cast<size_t>(end - begin))) {
+    // Verify `end - begin` did not underflow.
+    CHECK(begin <= end);
+  }
+
+  template <size_t N>
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr span(T (&arr)[N]) noexcept
+      // SAFETY: The std::ranges::size() function gives the number of elements
+      // pointed to by the std::ranges::data() function, which meets the
+      // requirement of span.
+      : UNSAFE_BUFFERS(span(std::ranges::data(arr), std::ranges::size(arr))) {}
+
+  template <typename R>
+    requires(internal::LegacyCompatibleRange<T, R>)
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr span(R&& range) noexcept
+      // SAFETY: The std::ranges::size() function gives the number of elements
+      // pointed to by the std::ranges::data() function, which meets the
+      // requirement of span.
+      : UNSAFE_BUFFERS(
+            span(std::ranges::data(range), std::ranges::size(range))) {}
+
+  // [span.sub], span subviews
+  template <size_t Count>
+  constexpr span<T, Count> first() const noexcept {
+    CHECK_LE(Count, size());
+    // SAFETY: span provides that data() points to at least `size()` many
+    // elements. `Count` is non-negative by its type and `Count <= size()` from
+    // the CHECK above. So `Count` is a valid new size for `data()`.
+    return UNSAFE_BUFFERS(span<T, Count>(data(), Count));
+  }
+
+  template <size_t Count>
+  constexpr span<T, Count> last() const noexcept {
+    CHECK_LE(Count, size());
+    // SAFETY: span provides that data() points to at least `size()` many
+    // elements. `Count` is non-negative by its type and `Count <= size()` from
+    // the check above. So `0 <= size() - Count <= size()`, meaning
+    // `size() - Count` is a valid new size for `data()` and it will point to
+    // `Count` many elements.
+    return UNSAFE_BUFFERS(span<T, Count>(data() + (size() - Count), Count));
+  }
+
+  // Returns a span over the first `count` elements.
+  //
+  // # Checks
+  // The function CHECKs that the span contains at least `count` elements and
+  // will terminate otherwise.
+  constexpr span<T> first(StrictNumeric<size_t> count) const noexcept {
+    CHECK_LE(size_t{count}, size());
+    // SAFETY: span provides that data() points to at least `size()` many
+    // elements. `count` is non-negative by its type and `count <= size()` from
+    // the CHECK above. So `count` is a valid new size for `data()`.
+    return UNSAFE_BUFFERS({data(), count});
+  }
+
+  // Returns a span over the last `count` elements.
+  //
+  // # Checks
+  // The function CHECKs that the span contains at least `count` elements and
+  // will terminate otherwise.
+  constexpr span<T> last(StrictNumeric<size_t> count) const noexcept {
+    CHECK_LE(size_t{count}, size());
+    // SAFETY: span provides that data() points to at least `size()` many
+    // elements. `count` is non-negative by its type and `count <= size()` from
+    // the CHECK above. So `0 <= size() - count <= size()`, meaning
+    // `size() - count` is a valid new size for `data()` and it will point to
+    // `count` many elements.
+    return UNSAFE_BUFFERS({data() + (size() - size_t{count}), count});
+  }
+
+  template <size_t Offset, size_t Count = dynamic_extent>
+  constexpr span<T, Count> subspan() const noexcept {
+    CHECK_LE(Offset, size());
+    CHECK(Count == dynamic_extent || Count <= size() - Offset);
+    const size_t new_extent = Count != dynamic_extent ? Count : size() - Offset;
+    // SAFETY: span provides that data() points to at least `size()` many
+    // elements.
+    //
+    // If Count is dynamic_extent, `new_extent` becomes `size() - Offset`. Since
+    // `Offset <= size()` from the check above, then `Offset` is a valid offset
+    // for data(), and `Offset + new_extent = Offset + size() - Offset = size()
+    // >= Offset` is also a valid offset that is not before `Offset`. This makes
+    // a span at `Offset` with size `new_extent` valid.
+    //
+    // Otherwise `Count <= size() - Offset` and `0 <= Offset <= size()` by the
+    // check above, so `Offset <= size() - Count` and `size() - Count` can not
+    // underflow. Then `Offset` is a valid offset for data() and `new_extent` is
+    // `Count <= size() - Offset`, so `Offset + extent <= Offset + size() -
+    // Offset = size()` which makes both `Offset` and `Offset + new_extent`
+    // valid offsets for data(), and since `new_extent` is non-negative, `Offset
+    // + new_extent` is not before `Offset` so `new_extent` is a valid size for
+    // the span at `data() + Offset`.
+    return UNSAFE_BUFFERS(span<T, Count>(data() + Offset, new_extent));
+  }
+
+  // Returns a span over the first `count` elements starting at the given
+  // `offset` from the start of the span.
+  //
+  // # Checks
+  // The function CHECKs that the span contains at least `offset + count`
+  // elements, or at least `offset` elements if `count` is not specified, and
+  // will terminate otherwise.
+  constexpr span<T> subspan(size_t offset,
+                            size_t count = dynamic_extent) const noexcept {
+    CHECK_LE(offset, size());
+    CHECK(count == dynamic_extent || count <= size() - offset);
+    const size_t new_extent = count != dynamic_extent ? count : size() - offset;
+    // SAFETY: span provides that data() points to at least `size()` many
+    // elements.
+    //
+    // If count is dynamic_extent, `new_extent` becomes `size() - offset`. Since
+    // `offset <= size()` from the check above, then `offset` is a valid offset
+    // for data(), and `offset + new_extent = offset + size() - offset = size()
+    // >= offset` is also a valid offset that is not before `offset`. This makes
+    // a span at `offset` with size `new_extent` valid.
+    //
+    // Otherwise `count <= size() - offset` and `0 <= offset <= size()` by the
+    // checks above, so `offset <= size() - count` and `size() - count` can not
+    // underflow. Then `offset` is a valid offset for data() and `new_extent` is
+    // `count <= size() - offset`, so `offset + new_extent <= offset + size() -
+    // offset = size()` which makes both `offset` and `offset + new_extent`
+    // valid offsets for data(), and since `new_extent` is non-negative, `offset
+    // + new_extent` is not before `offset` so `new_extent` is a valid size for
+    // the span at `data() + offset`.
+    return UNSAFE_BUFFERS({data() + offset, new_extent});
+  }
+
+  // Splits a span into two at the given `offset`, returning two spans that
+  // cover the full range of the original span.
+  //
+  // Similar to calling subspan() with the `offset` as the length on the first
+  // call, and then the `offset` as the offset in the second.
+  //
+  // The split_at<N>() overload allows construction of a fixed-size span from a
+  // compile-time constant. If the input span is fixed-size, both output output
+  // spans will be. Otherwise, the first will be fixed-size and the second will
+  // be dynamic-size.
+  //
+  // This is a non-std extension that  is inspired by the Rust slice::split_at()
+  // and split_at_mut() methods.
+  //
+  // # Checks
+  // The function CHECKs that the span contains at least `offset` elements and
+  // will terminate otherwise.
+  constexpr std::pair<span<T>, span<T>> split_at(size_t offset) const noexcept {
+    return {first(offset), subspan(offset)};
+  }
+
+  // An overload of `split_at` which returns a fixed-size span.
+  //
+  // # Checks
+  // The function CHECKs that the span contains at least `Offset` elements and
+  // will terminate otherwise.
+  template <size_t Offset>
+  constexpr std::pair<span<T, Offset>, span<T>> split_at() const noexcept {
+    CHECK_LE(Offset, size());
+    return {first<Offset>(), subspan(Offset)};
+  }
+
+  // [span.obs], span observers
+  constexpr size_t size() const noexcept { return size_; }
+  constexpr size_t size_bytes() const noexcept { return size() * sizeof(T); }
+  [[nodiscard]] constexpr bool empty() const noexcept { return size() == 0; }
+
+  // [span.elem], span element access
+  //
+  // # Checks
+  // The function CHECKs that the `idx` is inside the span and will terminate
+  // otherwise.
+  constexpr T& operator[](size_t idx) const noexcept {
+    CHECK_LT(idx, size());
+    // SAFETY: Since data() always points to at least `size()` elements, the
+    // check above ensures `idx < size()` and is thus in range for data().
+    return UNSAFE_BUFFERS(data()[idx]);
+  }
+
+  // Returns a reference to the first element in the span.
+  //
+  // # Checks
+  // The function CHECKs that the span is not empty and will terminate
+  // otherwise.
+  constexpr T& front() const noexcept {
+    CHECK(!empty());
+    // SAFETY: Since data() always points to at least `size()` elements, the
+    // check above above ensures `0 < size()` and is thus in range for data().
+    return UNSAFE_BUFFERS(data()[0]);
+  }
+
+  // Returns a reference to the last element in the span.
+  //
+  // # Checks
+  // The function CHECKs that the span is not empty and will terminate
+  // otherwise.
+  constexpr T& back() const noexcept {
+    CHECK(!empty());
+    // SAFETY: Since data() always points to at least `size()` elements, the
+    // check above above ensures `size() > 0` and thus `size() - 1` does not
+    // underflow and is in range for data().
+    return UNSAFE_BUFFERS(data()[size() - 1]);
+  }
+
+  // Returns a pointer to the first element in the span. If the span is empty
+  // (`size()` is 0), the returned pointer may or may not be null, and it must
+  // not be dereferenced.
+  //
+  // It is always valid to add `size()` to the the pointer in C++ code, though
+  // it may be invalid in C code when the span is empty.
+  constexpr T* data() const noexcept { return data_; }
+
+  // [span.iter], span iterator support
+  constexpr iterator begin() const noexcept {
+    // SAFETY: span provides that data() points to at least `size()` many
+    // elements, and size() is non-negative. So data() + size() is a valid
+    // pointer for the data() allocation.
+    return UNSAFE_BUFFERS(iterator(data(), data() + size()));
+  }
+
+  constexpr iterator end() const noexcept {
+    // SAFETY: span provides that data() points to at least `size()` many
+    // elements, and size() is non-negative. So data() + size() is a valid
+    // pointer for the data() allocation.
+    return UNSAFE_BUFFERS(iterator(data(), data() + size(), data() + size()));
+  }
+
+  constexpr reverse_iterator rbegin() const noexcept {
+    return reverse_iterator(end());
+  }
+
+  constexpr reverse_iterator rend() const noexcept {
+    return reverse_iterator(begin());
+  }
+
+  // Bounds-checked copy from a non-overlapping span. The spans must be the
+  // exact same size or a hard CHECK() occurs. If the two spans overlap,
+  // Undefined Behaviour occurs.
+  //
+  // This is a non-std extension that is inspired by the Rust
+  // slice::copy_from_slice() method.
+  //
+  // # Checks
+  // The function CHECKs that the `other` span has the same size as itself and
+  // will terminate otherwise.
+  constexpr void copy_from(span<const T> other)
+    requires(!std::is_const_v<T>)
+  {
+    CHECK_EQ(size_bytes(), other.size_bytes());
+    // Verify non-overlapping in developer builds.
+    //
+    // SAFETY: span provides that data() points to at least size() many
+    // elements, so adding size() to the data() pointer is well-defined.
+    DCHECK(UNSAFE_BUFFERS(data() + size()) <= other.data() ||
+           data() >= UNSAFE_BUFFERS(other.data() + other.size()));
+    // When compiling with -Oz, std::ranges::copy() does not get inlined, which
+    // makes copy_from() very expensive compared to memcpy for small sizes (up
+    // to around 4x slower). We observe that this is because ranges::copy() uses
+    // begin()/end() and span's iterators are checked iterators, not just
+    // pointers. This additional complexity prevents inlining and breaks the
+    // ability for the compiler to eliminate code.
+    //
+    // See also https://crbug.com/1396134.
+    //
+    // We also see std::copy() (with pointer arguments! not iterators) optimize
+    // and inline better than memcpy() since memcpy() needs to rely on
+    // size_bytes(), which while computable at compile time when `other` has a
+    // fixed size, the optimizer stumbles on with -Oz.
+    //
+    // SAFETY: The copy() here does not check bounds, but we have verified that
+    // `this` and `other` have the same bounds above (and are pointers of the
+    // same type), so `data()` and `other.data()` both have at least
+    // `other.size()` elements.
+    UNSAFE_BUFFERS(
+        std::copy(other.data(), other.data() + other.size(), data()));
+  }
+
+  // Compares two spans for equality by comparing the objects pointed to by the
+  // spans. The operation is defined for spans of different types as long as the
+  // types are themselves comparable.
+  //
+  // For primitive types, this replaces the less safe `memcmp` function, where
+  // `memcmp(a.data(), b.data(), a.size())` can be written as `a == b` and can
+  // no longer go outside the bounds of `b`. Otherwise, it replaced std::equal
+  // or std::ranges::equal when working with spans, and when no projection is
+  // needed.
+  //
+  // If the spans are of different sizes, they are not equal. If both spans are
+  // empty, they are always equal (even though their data pointers may differ).
+  //
+  // # Implementation note
+  // The non-template overloads allow implicit conversions to span for
+  // comparison.
+  friend constexpr bool operator==(span lhs, span rhs)
+    requires(std::equality_comparable<const T>)
+  {
+    return internal::span_cmp(span<const T>(lhs), span<const T>(rhs));
+  }
+  friend constexpr bool operator==(span lhs, span<const T> rhs)
+    requires(!std::is_const_v<T> && std::equality_comparable<const T>)
+  {
+    return internal::span_cmp(span<const T>(lhs), span<const T>(rhs));
+  }
+  template <class U, size_t M>
+    requires(std::equality_comparable_with<const T, const U>)
+  friend constexpr bool operator==(span lhs, span<U, M> rhs) {
+    return internal::span_cmp(span<const T>(lhs), span<const U, M>(rhs));
+  }
+
+ private:
+  // This field is not a raw_ptr<> since span is mostly used for stack
+  // variables. Use `raw_span` instead for class fields, which does use
+  // raw_ptr<> internally.
+  InternalPtrType data_ = nullptr;
+  size_t size_ = 0;
+};
+
+// [span.deduct], deduction guides.
+template <typename It, typename EndOrSize>
+  requires(std::contiguous_iterator<It>)
+span(It, EndOrSize) -> span<std::remove_reference_t<std::iter_reference_t<It>>>;
+
+template <
+    typename R,
+    typename T = std::remove_reference_t<std::ranges::range_reference_t<R>>>
+  requires(std::ranges::contiguous_range<R>)
+span(R&&)
+    -> span<std::conditional_t<std::ranges::borrowed_range<R>, T, const T>,
+            internal::ExtentV<R>>;
+
+// This guide prefers to let the contiguous_range guide match, since it can
+// produce a fixed-size span. Whereas, LegacyRange only produces a dynamic-sized
+// span.
+template <typename R>
+  requires(!std::ranges::contiguous_range<R> && internal::LegacyRange<R>)
+span(R&& r) noexcept
+    -> span<std::remove_reference_t<decltype(*std::ranges::data(r))>>;
+
+template <typename T, size_t N>
+span(const T (&)[N]) -> span<const T, N>;
+
+// [span.objectrep], views of object representation
+template <typename T, size_t X>
+constexpr auto as_bytes(span<T, X> s) noexcept {
+  constexpr size_t N = X == dynamic_extent ? dynamic_extent : sizeof(T) * X;
+  // SAFETY: span provides that data() points to at least size_bytes() many
+  // bytes. So since `uint8_t` has a size of 1 byte, the size_bytes() value is
+  // a valid size for a span at data() when viewed as `uint8_t*`.
+  //
+  // The reinterpret_cast is valid as the alignment of uint8_t (which is 1) is
+  // always less-than or equal to the alignment of T.
+  return UNSAFE_BUFFERS(span<const uint8_t, N>(
+      reinterpret_cast<const uint8_t*>(s.data()), s.size_bytes()));
+}
+
+template <typename T, size_t X>
+  requires(!std::is_const_v<T>)
+constexpr auto as_writable_bytes(span<T, X> s) noexcept {
+  constexpr size_t N = X == dynamic_extent ? dynamic_extent : sizeof(T) * X;
+  // SAFETY: span provides that data() points to at least size_bytes() many
+  // bytes. So since `uint8_t` has a size of 1 byte, the size_bytes() value is a
+  // valid size for a span at data() when viewed as `uint8_t*`.
+  //
+  // The reinterpret_cast is valid as the alignment of uint8_t (which is 1) is
+  // always less-than or equal to the alignment of T.
+  return UNSAFE_BUFFERS(
+      span<uint8_t, N>(reinterpret_cast<uint8_t*>(s.data()), s.size_bytes()));
+}
+
+// as_chars() is the equivalent of as_bytes(), except that it returns a
+// span of const char rather than const uint8_t. This non-std function is
+// added since chrome still represents many things as char arrays which
+// rightfully should be uint8_t.
+template <typename T, size_t X>
+constexpr auto as_chars(span<T, X> s) noexcept {
+  constexpr size_t N = X == dynamic_extent ? dynamic_extent : sizeof(T) * X;
+  // SAFETY: span provides that data() points to at least size_bytes() many
+  // bytes. So since `char` has a size of 1 byte, the size_bytes() value is a
+  // valid size for a span at data() when viewed as `char*`.
+  //
+  // The reinterpret_cast is valid as the alignment of char (which is 1) is
+  // always less-than or equal to the alignment of T.
+  return UNSAFE_BUFFERS(span<const char, N>(
+      reinterpret_cast<const char*>(s.data()), s.size_bytes()));
+}
+
+// as_string_view() converts a span over byte-sized primitives (holding chars or
+// uint8_t) into a std::string_view, where each byte is represented as a char.
+// It also accepts any type that can implicitly convert to a span, such as
+// arrays.
+//
+// If you want to view an arbitrary span type as a string, first explicitly
+// convert it to bytes via `base::as_bytes()`.
+//
+// For spans over byte-sized primitives, this is sugar for:
+// ```
+// std::string_view(as_chars(span).begin(), as_chars(span).end())
+// ```
+constexpr std::string_view as_string_view(span<const char> s) noexcept {
+  return std::string_view(s.begin(), s.end());
+}
+constexpr std::string_view as_string_view(
+    span<const unsigned char> s) noexcept {
+  const auto c = as_chars(s);
+  return std::string_view(c.begin(), c.end());
+}
+
+// as_writable_chars() is the equivalent of as_writable_bytes(), except that
+// it returns a span of char rather than uint8_t. This non-std function is
+// added since chrome still represents many things as char arrays which
+// rightfully should be uint8_t.
+template <typename T, size_t X>
+  requires(!std::is_const_v<T>)
+auto as_writable_chars(span<T, X> s) noexcept {
+  constexpr size_t N = X == dynamic_extent ? dynamic_extent : sizeof(T) * X;
+  // SAFETY: span provides that data() points to at least size_bytes() many
+  // bytes. So since `char` has a size of 1 byte, the size_bytes() value is
+  // a valid size for a span at data() when viewed as `char*`.
+  //
+  // The reinterpret_cast is valid as the alignment of char (which is 1) is
+  // always less-than or equal to the alignment of T.
+  return UNSAFE_BUFFERS(
+      span<char, N>(reinterpret_cast<char*>(s.data()), s.size_bytes()));
+}
+
+// Type-deducing helper for constructing a span.
+//
+// # Safety
+// The contiguous iterator `it` must point to the first element of at least
+// `size` many elements or Undefined Behaviour may result as the span may give
+// access beyond the bounds of the collection pointed to by `it`.
+template <int&... ExplicitArgumentBarrier, typename It>
+UNSAFE_BUFFER_USAGE constexpr auto make_span(
+    It it,
+    StrictNumeric<size_t> size) noexcept {
+  using T = std::remove_reference_t<std::iter_reference_t<It>>;
+  // SAFETY: The caller guarantees that `it` is the first of at least `size`
+  // many elements.
+  return UNSAFE_BUFFERS(span<T>(it, size));
+}
+
+// Type-deducing helper for constructing a span.
+//
+// # Checks
+// The function CHECKs that `it <= end` and will terminate otherwise.
+//
+// # Safety
+// The contiguous iterator `it` and its end sentinel `end` must be for the same
+// allocation or Undefined Behaviour may result as the span may give access
+// beyond the bounds of the collection pointed to by `it`.
+template <int&... ExplicitArgumentBarrier,
+          typename It,
+          typename End,
+          typename = std::enable_if_t<!std::is_convertible_v<End, size_t>>>
+UNSAFE_BUFFER_USAGE constexpr auto make_span(It it, End end) noexcept {
+  using T = std::remove_reference_t<std::iter_reference_t<It>>;
+  // SAFETY: The caller guarantees that `it` and `end` are iterators of the
+  // same allocation.
+  return UNSAFE_BUFFERS(span<T>(it, end));
+}
+
+// make_span utility function that deduces both the span's value_type and extent
+// from the passed in argument.
+//
+// Usage: auto span = base::make_span(...);
+template <int&... ExplicitArgumentBarrier, typename Container>
+constexpr auto make_span(Container&& container) noexcept {
+  using T =
+      std::remove_pointer_t<decltype(std::data(std::declval<Container>()))>;
+  using Extent = internal::Extent<Container>;
+  return span<T, Extent::value>(std::forward<Container>(container));
+}
+
+// make_span utility function that allows callers to explicit specify the span's
+// extent, the value_type is deduced automatically. This is useful when passing
+// a dynamically sized container to a method expecting static spans, when the
+// container is known to have the correct size.
+//
+// Note: This will CHECK that N indeed matches size(container).
+//
+// # Usage
+// As this function is unsafe, the caller must guarantee that the size is
+// correct for the iterator, and will not allow the span to reach out of bounds.
+// ```
+// // SAFETY: <An explanation of how the size is checked/ensured to always be
+// // valid for the iterator>.
+// auto static_span = UNSAFE_BUFFERS(base::make_span<N>(it, size));
+// ```
+//
+// # Safety
+// The contiguous iterator `it` must point to the first element of at least
+// `size` many elements or Undefined Behaviour may result as the span may give
+// access beyond the bounds of the collection pointed to by `it`.
+template <size_t N, int&... ExplicitArgumentBarrier, typename It>
+UNSAFE_BUFFER_USAGE constexpr auto make_span(
+    It it,
+    StrictNumeric<size_t> size) noexcept {
+  using T = std::remove_reference_t<std::iter_reference_t<It>>;
+  // SAFETY: The caller guarantees that `it` is the first of at least `size`
+  // many elements.
+  return UNSAFE_BUFFERS(span<T, N>(it, size));
+}
+
+// make_span utility function that allows callers to explicit specify the span's
+// extent, the value_type is deduced automatically. This is useful when passing
+// a dynamically sized container to a method expecting static spans, when the
+// container is known to have the correct size.
+//
+// Note: This will CHECK that N indeed matches size(container).
+//
+// # Usage
+// As this function is unsafe, the caller must guarantee that the `end` is from
+// the same allocation as the `it` iterator.
+// ```
+// // SAFETY: <An explanation if non-trivial how the iterators are not from
+// // different containers/allocations>.
+// auto static_span = UNSAFE_BUFFERS(base::make_span<N>(it, end));
+// ```
+//
+// # Checks
+// The function CHECKs that `it <= end` and will terminate otherwise.
+//
+// # Safety
+// The contiguous iterator `it` and its end sentinel `end` must be for the same
+// allocation or Undefined Behaviour may result as the span may give access
+// beyond the bounds of the collection pointed to by `it`.
+template <size_t N,
+          int&... ExplicitArgumentBarrier,
+          typename It,
+          typename End,
+          typename = std::enable_if_t<!std::is_convertible_v<End, size_t>>>
+UNSAFE_BUFFER_USAGE constexpr auto make_span(It it, End end) noexcept {
+  using T = std::remove_reference_t<std::iter_reference_t<It>>;
+  // SAFETY: The caller guarantees that `it` and `end` are iterators of the
+  // same allocation.
+  return UNSAFE_BUFFERS(span<T, N>(it, end));
+}
+
+template <size_t N, int&... ExplicitArgumentBarrier, typename Container>
+constexpr auto make_span(Container&& container) noexcept {
+  using T =
+      std::remove_pointer_t<decltype(std::data(std::declval<Container>()))>;
+  // SAFETY: The std::size() function gives the number of elements pointed to by
+  // the std::data() function, which meets the requirement of span.
+  return UNSAFE_BUFFERS(span<T, N>(std::data(container), std::size(container)));
+}
+
+// `span_from_ref` converts a reference to T into a span of length 1.  This is a
+// non-std helper that is inspired by the `std::slice::from_ref()` function from
+// Rust.
+template <typename T>
+constexpr span<T, 1u> span_from_ref(
+    T& single_object ABSL_ATTRIBUTE_LIFETIME_BOUND) noexcept {
+  // SAFETY: Given a valid reference to `single_object` the span of size 1 will
+  // be a valid span that points to the `single_object`.
+  return UNSAFE_BUFFERS(span<T, 1u>(std::addressof(single_object), 1u));
+}
+
+// `byte_span_from_ref` converts a reference to T into a span of uint8_t of
+// length sizeof(T).  This is a non-std helper that is a sugar for
+// `as_writable_bytes(span_from_ref(x))`.
+//
+// Const references are turned into a `span<const T, sizeof(T)>` while mutable
+// references are turned into a `span<T, sizeof(T)>`.
+template <typename T>
+constexpr span<const uint8_t, sizeof(T)> byte_span_from_ref(
+    const T& single_object ABSL_ATTRIBUTE_LIFETIME_BOUND) noexcept {
+  return as_bytes(span_from_ref(single_object));
+}
+template <typename T>
+constexpr span<uint8_t, sizeof(T)> byte_span_from_ref(
+    T& single_object ABSL_ATTRIBUTE_LIFETIME_BOUND) noexcept {
+  return as_writable_bytes(span_from_ref(single_object));
+}
+
+// Converts a string literal (such as `"hello"`) to a span of `char` while
+// omitting the terminating NUL character. These two are equivalent:
+// ```
+// base::span<char, 5u> s1 = base::span_from_cstring("hello");
+// base::span<char, 5u> s2 = base::span(std::string_view("hello"));
+// ```
+//
+// If you want to include the NUL terminator, then use the span constructor
+// directly, such as:
+// ```
+// base::span<char, 6u> s = base::span("hello");
+// ```
+template <size_t N>
+constexpr span<const char, N - 1> span_from_cstring(
+    const char (&lit ABSL_ATTRIBUTE_LIFETIME_BOUND)[N]) {
+  return span(lit).template first<N - 1>();
+}
+
+// Converts a string literal (such as `"hello"`) to a span of `uint8_t` while
+// omitting the terminating NUL character. These two are equivalent:
+// ```
+// base::span<uint8_t, 5u> s1 = base::byte_span_from_cstring("hello");
+// base::span<uint8_t, 5u> s2 = base::as_byte_span(std::string_view("hello"));
+// ```
+//
+// If you want to include the NUL terminator, then use the span constructor
+// directly, such as:
+// ```
+// base::span<uint8_t, 6u> s = base::as_bytes(base::span("hello"));
+// ```
+template <size_t N>
+constexpr span<const uint8_t, N - 1> byte_span_from_cstring(
+    const char (&lit ABSL_ATTRIBUTE_LIFETIME_BOUND)[N]) {
+  return as_bytes(span(lit).template first<N - 1>());
+}
+
+// Convenience function for converting an object which is itself convertible
+// to span into a span of bytes (i.e. span of const uint8_t). Typically used
+// to convert std::string or string-objects holding chars, or std::vector
+// or vector-like objects holding other scalar types, prior to passing them
+// into an API that requires byte spans.
+template <typename T>
+  requires requires(const T& arg) {
+    requires !std::is_array_v<std::remove_reference_t<T>>;
+    make_span(arg);
+  }
+constexpr span<const uint8_t> as_byte_span(const T& arg) {
+  return as_bytes(make_span(arg));
+}
+
+// This overload for arrays preserves the compile-time size N of the array in
+// the span type signature span<uint8_t, N>.
+template <typename T, size_t N>
+constexpr span<const uint8_t, N * sizeof(T)> as_byte_span(
+    const T (&arr ABSL_ATTRIBUTE_LIFETIME_BOUND)[N]) {
+  return as_bytes(make_span<N>(arr));
+}
+
+// Convenience function for converting an object which is itself convertible
+// to span into a span of mutable bytes (i.e. span of uint8_t). Typically used
+// to convert std::string or string-objects holding chars, or std::vector
+// or vector-like objects holding other scalar types, prior to passing them
+// into an API that requires mutable byte spans.
+template <typename T>
+  requires requires(T&& arg) {
+    requires !std::is_array_v<std::remove_reference_t<T>>;
+    make_span(arg);
+    requires !std::is_const_v<typename decltype(make_span(arg))::element_type>;
+  }
+constexpr span<uint8_t> as_writable_byte_span(T&& arg) {
+  return as_writable_bytes(make_span(arg));
+}
+
+// This overload for arrays preserves the compile-time size N of the array in
+// the span type signature span<uint8_t, N>.
+template <typename T, size_t N>
+  requires(!std::is_const_v<T>)
+constexpr span<uint8_t, N * sizeof(T)> as_writable_byte_span(
+    T (&arr ABSL_ATTRIBUTE_LIFETIME_BOUND)[N]) {
+  return as_writable_bytes(make_span<N>(arr));
+}
+template <typename T, size_t N>
+  requires(!std::is_const_v<T>)
+constexpr span<uint8_t, N * sizeof(T)> as_writable_byte_span(
+    T (&&arr ABSL_ATTRIBUTE_LIFETIME_BOUND)[N]) {
+  return as_writable_bytes(make_span<N>(arr));
+}
+
+namespace internal {
+
+// Template helper for implementing operator==.
+template <class T, class U, size_t N, size_t M>
+  requires((N == M || N == dynamic_extent || M == dynamic_extent) &&
+           std::equality_comparable_with<T, U>)
+constexpr bool span_cmp(span<T, N> l, span<U, M> r) {
+  return l.size() == r.size() && std::equal(l.begin(), l.end(), r.begin());
+}
+
+}  // namespace internal
+
+}  // namespace base
+
+template <typename T, size_t N, typename Ptr>
+inline constexpr bool
+    std::ranges::enable_borrowed_range<base::span<T, N, Ptr>> = true;
+
+template <typename T, size_t N, typename Ptr>
+inline constexpr bool std::ranges::enable_view<base::span<T, N, Ptr>> = true;
+
+// EXTENT returns the size of any type that can be converted to a |base::span|
+// with definite extent, i.e. everything that is a contiguous storage of some
+// sort with static size. Specifically, this works for std::array in a constexpr
+// context. Note:
+//   * |std::size| should be preferred for plain arrays.
+//   * In run-time contexts, functions such as |std::array::size| should be
+//     preferred.
+#define EXTENT(x)                                                          \
+  ::base::internal::must_not_be_dynamic_extent<decltype(::base::make_span( \
+      x))::extent>()
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_CONTAINERS_SPAN_H_

--- a/internal/base/containers/util.h
+++ b/internal/base/containers/util.h
@@ -1,0 +1,25 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_CONTAINERS_UTIL_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_CONTAINERS_UTIL_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include <stdint.h>
+
+namespace base {
+
+// TODO(crbug.com/40565371): What we really need is for checked_math.h to be
+// able to do checked arithmetic on pointers.
+template <typename T>
+inline uintptr_t get_uintptr(const T* t) {
+  return reinterpret_cast<uintptr_t>(t);
+}
+
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_CONTAINERS_UTIL_H_

--- a/internal/base/files.h
+++ b/internal/base/files.h
@@ -15,6 +15,10 @@
 #ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_FILES_H_
 #define THIRD_PARTY_NEARBY_INTERNAL_BASE_FILES_H_
 
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
 #include <cstdint>
 #include <filesystem>  // NOLINT(build/c++17)
 #include <optional>

--- a/internal/base/memory/raw_ptr_exclusion.h
+++ b/internal/base/memory/raw_ptr_exclusion.h
@@ -12,18 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "internal/crypto_cros/random.h"
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_MEMORY_RAW_PTR_EXCLUSION_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_MEMORY_RAW_PTR_EXCLUSION_H_
 
-#include <stddef.h>
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
 
-#include <string>
+// Not defined for standalone builds.
+#define RAW_PTR_EXCLUSION
 
-#include <openssl/rand.h>
-
-namespace crypto {
-
-void RandBytes(base::span<uint8_t> bytes) {
-  RAND_bytes(bytes.data(), bytes.size());
-}
-
-}  // namespace crypto
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_MEMORY_RAW_PTR_EXCLUSION_H_

--- a/internal/base/numerics/angle_conversions.h
+++ b/internal/base/numerics/angle_conversions.h
@@ -1,0 +1,31 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_ANGLE_CONVERSIONS_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_ANGLE_CONVERSIONS_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include <concepts>
+#include <numbers>
+
+namespace base {
+
+template <typename T>
+  requires std::floating_point<T>
+constexpr T DegToRad(T deg) {
+  return deg * std::numbers::pi_v<T> / 180;
+}
+
+template <typename T>
+  requires std::floating_point<T>
+constexpr T RadToDeg(T rad) {
+  return rad * 180 / std::numbers::pi_v<T>;
+}
+
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_ANGLE_CONVERSIONS_H_

--- a/internal/base/numerics/basic_ops_impl.h
+++ b/internal/base/numerics/basic_ops_impl.h
@@ -1,0 +1,157 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_BASIC_OPS_IMPL_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_BASIC_OPS_IMPL_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <span>
+#include <type_traits>
+
+namespace base::internal {
+
+// The correct type to perform math operations on given values of type `T`. This
+// may be a larger type than `T` to avoid promotion to `int` which involves sign
+// conversion!
+template <class T>
+  requires(std::is_integral_v<T>)
+using MathType = std::conditional_t<
+    sizeof(T) >= sizeof(int),
+    T,
+    std::conditional_t<std::is_signed_v<T>, int, unsigned int>>;
+
+// Reverses the byte order of the integer.
+template <class T>
+  requires(std::is_unsigned_v<T> && std::is_integral_v<T>)
+inline constexpr T SwapBytes(T value) {
+  // MSVC intrinsics are not constexpr, so we provide our own constexpr
+  // implementation. We provide it unconditionally so we can test it on all
+  // platforms for correctness.
+  if (std::is_constant_evaluated()) {
+    if constexpr (sizeof(T) == 1u) {
+      return value;
+    } else if constexpr (sizeof(T) == 2u) {
+      MathType<T> a = (MathType<T>(value) >> 0) & MathType<T>{0xff};
+      MathType<T> b = (MathType<T>(value) >> 8) & MathType<T>{0xff};
+      return static_cast<T>((a << 8) | (b << 0));
+    } else if constexpr (sizeof(T) == 4u) {
+      T a = (value >> 0) & T{0xff};
+      T b = (value >> 8) & T{0xff};
+      T c = (value >> 16) & T{0xff};
+      T d = (value >> 24) & T{0xff};
+      return (a << 24) | (b << 16) | (c << 8) | (d << 0);
+    } else {
+      static_assert(sizeof(T) == 8u);
+      T a = (value >> 0) & T{0xff};
+      T b = (value >> 8) & T{0xff};
+      T c = (value >> 16) & T{0xff};
+      T d = (value >> 24) & T{0xff};
+      T e = (value >> 32) & T{0xff};
+      T f = (value >> 40) & T{0xff};
+      T g = (value >> 48) & T{0xff};
+      T h = (value >> 56) & T{0xff};
+      return (a << 56) | (b << 48) | (c << 40) | (d << 32) |  //
+             (e << 24) | (f << 16) | (g << 8) | (h << 0);
+    }
+  }
+
+#if _MSC_VER
+  if constexpr (sizeof(T) == 1u) {
+    return value;
+  } else if constexpr (sizeof(T) == sizeof(unsigned short)) {
+    using U = unsigned short;
+    return _byteswap_ushort(U{value});
+  } else if constexpr (sizeof(T) == sizeof(unsigned long)) {
+    using U = unsigned long;
+    return _byteswap_ulong(U{value});
+  } else {
+    static_assert(sizeof(T) == 8u);
+    return _byteswap_uint64(value);
+  }
+#else
+  if constexpr (sizeof(T) == 1u) {
+    return value;
+  } else if constexpr (sizeof(T) == 2u) {
+    return __builtin_bswap16(uint16_t{value});
+  } else if constexpr (sizeof(T) == 4u) {
+    return __builtin_bswap32(value);
+  } else {
+    static_assert(sizeof(T) == 8u);
+    return __builtin_bswap64(value);
+  }
+#endif
+}
+
+// Signed values are byte-swapped as unsigned values.
+template <class T>
+  requires(std::is_signed_v<T> && std::is_integral_v<T>)
+inline constexpr T SwapBytes(T value) {
+  return static_cast<T>(SwapBytes(static_cast<std::make_unsigned_t<T>>(value)));
+}
+
+// Converts from a byte array to an integer.
+template <class T>
+  requires(std::is_unsigned_v<T> && std::is_integral_v<T>)
+inline constexpr T FromLittleEndian(std::span<const uint8_t, sizeof(T)> bytes) {
+  T val;
+  if (std::is_constant_evaluated()) {
+    val = T{0};
+    for (size_t i = 0u; i < sizeof(T); i += 1u) {
+      // SAFETY: `i < sizeof(T)` (the number of bytes in T), so `(8 * i)` is
+      // less than the number of bits in T.
+      val |= MathType<T>(bytes[i]) << (8u * i);
+    }
+  } else {
+    // SAFETY: `bytes` has sizeof(T) bytes, and `val` is of type `T` so has
+    // sizeof(T) bytes, and the two can not alias as `val` is a stack variable.
+    memcpy(&val, bytes.data(), sizeof(T));
+  }
+  return val;
+}
+
+template <class T>
+  requires(std::is_signed_v<T> && std::is_integral_v<T>)
+inline constexpr T FromLittleEndian(std::span<const uint8_t, sizeof(T)> bytes) {
+  return static_cast<T>(FromLittleEndian<std::make_unsigned_t<T>>(bytes));
+}
+
+// Converts to a byte array from an integer.
+template <class T>
+  requires(std::is_unsigned_v<T> && std::is_integral_v<T>)
+inline constexpr std::array<uint8_t, sizeof(T)> ToLittleEndian(T val) {
+  auto bytes = std::array<uint8_t, sizeof(T)>();
+  if (std::is_constant_evaluated()) {
+    for (size_t i = 0u; i < sizeof(T); i += 1u) {
+      const auto last_byte = static_cast<uint8_t>(val & 0xff);
+      // The low bytes go to the front of the array in little endian.
+      bytes[i] = last_byte;
+      // If `val` is one byte, this shift would be UB. But it's also not needed
+      // since the loop will not run again.
+      if constexpr (sizeof(T) > 1u) {
+        val >>= 8u;
+      }
+    }
+  } else {
+    // SAFETY: `bytes` has sizeof(T) bytes, and `val` is of type `T` so has
+    // sizeof(T) bytes, and the two can not alias as `val` is a stack variable.
+    memcpy(bytes.data(), &val, sizeof(T));
+  }
+  return bytes;
+}
+
+template <class T>
+  requires(std::is_signed_v<T> && std::is_integral_v<T>)
+inline constexpr std::array<uint8_t, sizeof(T)> ToLittleEndian(T val) {
+  return ToLittleEndian(static_cast<std::make_unsigned_t<T>>(val));
+}
+}  // namespace base::internal
+
+#endif  //  THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_BASIC_OPS_IMPL_H_

--- a/internal/base/numerics/byte_conversions.h
+++ b/internal/base/numerics/byte_conversions.h
@@ -1,0 +1,784 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_BYTE_CONVERSIONS_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_BYTE_CONVERSIONS_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <type_traits>
+
+#include "internal/base/numerics/basic_ops_impl.h"
+#include "internal/build/build_config.h"
+
+// Chromium only builds and runs on Little Endian machines.
+static_assert(ARCH_CPU_LITTLE_ENDIAN);
+
+namespace base {
+
+// Returns a value with all bytes in |x| swapped, i.e. reverses the endianness.
+// TODO(pkasting): Once C++23 is available, replace with std::byteswap.
+template <class T>
+  requires(std::is_integral_v<T>)
+inline constexpr T ByteSwap(T value) {
+  return internal::SwapBytes(value);
+}
+
+// Returns a uint8_t with the value in `bytes` interpreted as the native endian
+// encoding of the integer for the machine.
+//
+// This is suitable for decoding integers that were always kept in native
+// encoding, such as when stored in shared-memory (or through IPC) as a byte
+// buffer. Prefer an explicit little endian when storing and reading data from
+// storage, and explicit big endian for network order.
+//
+// Note that since a single byte can have only one ordering, this just copies
+// the byte out of the span. This provides a consistent function for the
+// operation nonetheless.
+inline constexpr uint8_t U8FromNativeEndian(
+    std::span<const uint8_t, 1u> bytes) {
+  return bytes[0];
+}
+// Returns a uint16_t with the value in `bytes` interpreted as the native endian
+// encoding of the integer for the machine.
+//
+// This is suitable for decoding integers that were always kept in native
+// encoding, such as when stored in shared-memory (or through IPC) as a byte
+// buffer. Prefer an explicit little endian when storing and reading data from
+// storage, and explicit big endian for network order.
+inline constexpr uint16_t U16FromNativeEndian(
+    std::span<const uint8_t, 2u> bytes) {
+  return internal::FromLittleEndian<uint16_t>(bytes);
+}
+// Returns a uint32_t with the value in `bytes` interpreted as the native endian
+// encoding of the integer for the machine.
+//
+// This is suitable for decoding integers that were always kept in native
+// encoding, such as when stored in shared-memory (or through IPC) as a byte
+// buffer. Prefer an explicit little endian when storing and reading data from
+// storage, and explicit big endian for network order.
+inline constexpr uint32_t U32FromNativeEndian(
+    std::span<const uint8_t, 4u> bytes) {
+  return internal::FromLittleEndian<uint32_t>(bytes);
+}
+// Returns a uint64_t with the value in `bytes` interpreted as the native endian
+// encoding of the integer for the machine.
+//
+// This is suitable for decoding integers that were always kept in native
+// encoding, such as when stored in shared-memory (or through IPC) as a byte
+// buffer. Prefer an explicit little endian when storing and reading data from
+// storage, and explicit big endian for network order.
+inline constexpr uint64_t U64FromNativeEndian(
+    std::span<const uint8_t, 8u> bytes) {
+  return internal::FromLittleEndian<uint64_t>(bytes);
+}
+// Returns a int8_t with the value in `bytes` interpreted as the native endian
+// encoding of the integer for the machine.
+//
+// This is suitable for decoding integers that were always kept in native
+// encoding, such as when stored in shared-memory (or through IPC) as a byte
+// buffer. Prefer an explicit little endian when storing and reading data from
+// storage, and explicit big endian for network order.
+//
+// Note that since a single byte can have only one ordering, this just copies
+// the byte out of the span. This provides a consistent function for the
+// operation nonetheless.
+inline constexpr int8_t I8FromNativeEndian(std::span<const uint8_t, 1u> bytes) {
+  return static_cast<int8_t>(bytes[0]);
+}
+// Returns a int16_t with the value in `bytes` interpreted as the native endian
+// encoding of the integer for the machine.
+//
+// This is suitable for decoding integers that were always kept in native
+// encoding, such as when stored in shared-memory (or through IPC) as a byte
+// buffer. Prefer an explicit little endian when storing and reading data from
+// storage, and explicit big endian for network order.
+inline constexpr int16_t I16FromNativeEndian(
+    std::span<const uint8_t, 2u> bytes) {
+  return internal::FromLittleEndian<int16_t>(bytes);
+}
+// Returns a int32_t with the value in `bytes` interpreted as the native endian
+// encoding of the integer for the machine.
+//
+// This is suitable for decoding integers that were always kept in native
+// encoding, such as when stored in shared-memory (or through IPC) as a byte
+// buffer. Prefer an explicit little endian when storing and reading data from
+// storage, and explicit big endian for network order.
+inline constexpr int32_t I32FromNativeEndian(
+    std::span<const uint8_t, 4u> bytes) {
+  return internal::FromLittleEndian<int32_t>(bytes);
+}
+// Returns a int64_t with the value in `bytes` interpreted as the native endian
+// encoding of the integer for the machine.
+//
+// This is suitable for decoding integers that were always kept in native
+// encoding, such as when stored in shared-memory (or through IPC) as a byte
+// buffer. Prefer an explicit little endian when storing and reading data from
+// storage, and explicit big endian for network order.
+inline constexpr int64_t I64FromNativeEndian(
+    std::span<const uint8_t, 8u> bytes) {
+  return internal::FromLittleEndian<int64_t>(bytes);
+}
+
+// Returns a float with the value in `bytes` interpreted as the native endian
+// encoding of the number for the machine.
+//
+// This is suitable for decoding numbers that were always kept in native
+// encoding, such as when stored in shared-memory (or through IPC) as a byte
+// buffer. Prefer an explicit little endian when storing and reading data from
+// storage, and explicit big endian for network order.
+inline constexpr float FloatFromNativeEndian(
+    std::span<const uint8_t, 4u> bytes) {
+  return std::bit_cast<float>(U32FromNativeEndian(bytes));
+}
+// Returns a double with the value in `bytes` interpreted as the native endian
+// encoding of the number for the machine.
+//
+// This is suitable for decoding numbers that were always kept in native
+// encoding, such as when stored in shared-memory (or through IPC) as a byte
+// buffer. Prefer an explicit little endian when storing and reading data from
+// storage, and explicit big endian for network order.
+inline constexpr double DoubleFromNativeEndian(
+    std::span<const uint8_t, 8u> bytes) {
+  return std::bit_cast<double>(U64FromNativeEndian(bytes));
+}
+
+// Returns a uint8_t with the value in `bytes` interpreted as a little-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in little endian,
+// which is a good practice with storing and reading data from storage. Use
+// the native-endian versions when working with values that were always in
+// memory, such as when stored in shared-memory (or through IPC) as a byte
+// buffer.
+//
+// Note that since a single byte can have only one ordering, this just copies
+// the byte out of the span. This provides a consistent function for the
+// operation nonetheless.
+inline constexpr uint8_t U8FromLittleEndian(
+    std::span<const uint8_t, 1u> bytes) {
+  return bytes[0];
+}
+// Returns a uint16_t with the value in `bytes` interpreted as a little-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in little endian,
+// which is a good practice with storing and reading data from storage. Use
+// the native-endian versions when working with values that were always in
+// memory, such as when stored in shared-memory (or through IPC) as a byte
+// buffer.
+inline constexpr uint16_t U16FromLittleEndian(
+    std::span<const uint8_t, 2u> bytes) {
+  return internal::FromLittleEndian<uint16_t>(bytes);
+}
+// Returns a uint32_t with the value in `bytes` interpreted as a little-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in little endian,
+// which is a good practice with storing and reading data from storage. Use
+// the native-endian versions when working with values that were always in
+// memory, such as when stored in shared-memory (or through IPC) as a byte
+// buffer.
+inline constexpr uint32_t U32FromLittleEndian(
+    std::span<const uint8_t, 4u> bytes) {
+  return internal::FromLittleEndian<uint32_t>(bytes);
+}
+// Returns a uint64_t with the value in `bytes` interpreted as a little-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in little endian,
+// which is a good practice with storing and reading data from storage. Use
+// the native-endian versions when working with values that were always in
+// memory, such as when stored in shared-memory (or through IPC) as a byte
+// buffer.
+inline constexpr uint64_t U64FromLittleEndian(
+    std::span<const uint8_t, 8u> bytes) {
+  return internal::FromLittleEndian<uint64_t>(bytes);
+}
+// Returns a int8_t with the value in `bytes` interpreted as a little-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in little endian,
+// which is a good practice with storing and reading data from storage. Use
+// the native-endian versions when working with values that were always in
+// memory, such as when stored in shared-memory (or through IPC) as a byte
+// buffer.
+//
+// Note that since a single byte can have only one ordering, this just copies
+// the byte out of the span. This provides a consistent function for the
+// operation nonetheless.
+inline constexpr int8_t I8FromLittleEndian(std::span<const uint8_t, 1u> bytes) {
+  return static_cast<int8_t>(bytes[0]);
+}
+// Returns a int16_t with the value in `bytes` interpreted as a little-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in little endian,
+// which is a good practice with storing and reading data from storage. Use
+// the native-endian versions when working with values that were always in
+// memory, such as when stored in shared-memory (or through IPC) as a byte
+// buffer.
+inline constexpr int16_t I16FromLittleEndian(
+    std::span<const uint8_t, 2u> bytes) {
+  return internal::FromLittleEndian<int16_t>(bytes);
+}
+// Returns a int32_t with the value in `bytes` interpreted as a little-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in little endian,
+// which is a good practice with storing and reading data from storage. Use
+// the native-endian versions when working with values that were always in
+// memory, such as when stored in shared-memory (or through IPC) as a byte
+// buffer.
+inline constexpr int32_t I32FromLittleEndian(
+    std::span<const uint8_t, 4u> bytes) {
+  return internal::FromLittleEndian<int32_t>(bytes);
+}
+// Returns a int64_t with the value in `bytes` interpreted as a little-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in little endian,
+// which is a good practice with storing and reading data from storage. Use
+// the native-endian versions when working with values that were always in
+// memory, such as when stored in shared-memory (or through IPC) as a byte
+// buffer.
+inline constexpr int64_t I64FromLittleEndian(
+    std::span<const uint8_t, 8u> bytes) {
+  return internal::FromLittleEndian<int64_t>(bytes);
+}
+// Returns a float with the value in `bytes` interpreted as a little-endian
+// encoding of the integer.
+//
+// This is suitable for decoding numbers encoded explicitly in little endian,
+// which is a good practice with storing and reading data from storage. Use
+// the native-endian versions when working with values that were always in
+// memory, such as when stored in shared-memory (or through IPC) as a byte
+// buffer.
+inline constexpr float FloatFromLittleEndian(
+    std::span<const uint8_t, 4u> bytes) {
+  return std::bit_cast<float>(U32FromLittleEndian(bytes));
+}
+// Returns a double with the value in `bytes` interpreted as a little-endian
+// encoding of the integer.
+//
+// This is suitable for decoding numbers encoded explicitly in little endian,
+// which is a good practice with storing and reading data from storage. Use
+// the native-endian versions when working with values that were always in
+// memory, such as when stored in shared-memory (or through IPC) as a byte
+// buffer.
+inline constexpr double DoubleFromLittleEndian(
+    std::span<const uint8_t, 8u> bytes) {
+  return std::bit_cast<double>(U64FromLittleEndian(bytes));
+}
+
+// Returns a uint8_t with the value in `bytes` interpreted as a big-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in big endian, such
+// as for network order. Use the native-endian versions when working with values
+// that were always in memory, such as when stored in shared-memory (or through
+// IPC) as a byte buffer.
+//
+// Note that since a single byte can have only one ordering, this just copies
+// the byte out of the span. This provides a consistent function for the
+// operation nonetheless.
+inline constexpr uint8_t U8FromBigEndian(std::span<const uint8_t, 1u> bytes) {
+  return bytes[0];
+}
+// Returns a uint16_t with the value in `bytes` interpreted as a big-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in big endian, such
+// as for network order. Use the native-endian versions when working with values
+// that were always in memory, such as when stored in shared-memory (or through
+// IPC) as a byte buffer.
+inline constexpr uint16_t U16FromBigEndian(std::span<const uint8_t, 2u> bytes) {
+  return ByteSwap(internal::FromLittleEndian<uint16_t>(bytes));
+}
+// Returns a uint32_t with the value in `bytes` interpreted as a big-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in big endian, such
+// as for network order. Use the native-endian versions when working with values
+// that were always in memory, such as when stored in shared-memory (or through
+// IPC) as a byte buffer.
+inline constexpr uint32_t U32FromBigEndian(std::span<const uint8_t, 4u> bytes) {
+  return ByteSwap(internal::FromLittleEndian<uint32_t>(bytes));
+}
+// Returns a uint64_t with the value in `bytes` interpreted as a big-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in big endian, such
+// as for network order. Use the native-endian versions when working with values
+// that were always in memory, such as when stored in shared-memory (or through
+// IPC) as a byte buffer.
+inline constexpr uint64_t U64FromBigEndian(std::span<const uint8_t, 8u> bytes) {
+  return ByteSwap(internal::FromLittleEndian<uint64_t>(bytes));
+}
+// Returns a int8_t with the value in `bytes` interpreted as a big-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in big endian, such
+// as for network order. Use the native-endian versions when working with values
+// that were always in memory, such as when stored in shared-memory (or through
+// IPC) as a byte buffer.
+//
+// Note that since a single byte can have only one ordering, this just copies
+// the byte out of the span. This provides a consistent function for the
+// operation nonetheless.
+inline constexpr int8_t I8FromBigEndian(std::span<const uint8_t, 1u> bytes) {
+  return static_cast<int8_t>(bytes[0]);
+}
+// Returns a int16_t with the value in `bytes` interpreted as a big-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in big endian, such
+// as for network order. Use the native-endian versions when working with values
+// that were always in memory, such as when stored in shared-memory (or through
+// IPC) as a byte buffer.
+inline constexpr int16_t I16FromBigEndian(std::span<const uint8_t, 2u> bytes) {
+  return ByteSwap(internal::FromLittleEndian<int16_t>(bytes));
+}
+// Returns a int32_t with the value in `bytes` interpreted as a big-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in big endian, such
+// as for network order. Use the native-endian versions when working with values
+// that were always in memory, such as when stored in shared-memory (or through
+// IPC) as a byte buffer.
+inline constexpr int32_t I32FromBigEndian(std::span<const uint8_t, 4u> bytes) {
+  return ByteSwap(internal::FromLittleEndian<int32_t>(bytes));
+}
+// Returns a int64_t with the value in `bytes` interpreted as a big-endian
+// encoding of the integer.
+//
+// This is suitable for decoding integers encoded explicitly in big endian, such
+// as for network order. Use the native-endian versions when working with values
+// that were always in memory, such as when stored in shared-memory (or through
+// IPC) as a byte buffer.
+inline constexpr int64_t I64FromBigEndian(std::span<const uint8_t, 8u> bytes) {
+  return ByteSwap(internal::FromLittleEndian<int64_t>(bytes));
+}
+// Returns a float with the value in `bytes` interpreted as a big-endian
+// encoding of the integer.
+//
+// This is suitable for decoding numbers encoded explicitly in big endian, such
+// as for network order. Use the native-endian versions when working with values
+// that were always in memory, such as when stored in shared-memory (or through
+// IPC) as a byte buffer.
+inline constexpr float FloatFromBigEndian(std::span<const uint8_t, 4u> bytes) {
+  return std::bit_cast<float>(U32FromBigEndian(bytes));
+}
+// Returns a double with the value in `bytes` interpreted as a big-endian
+// encoding of the integer.
+//
+// This is suitable for decoding numbers encoded explicitly in big endian, such
+// as for network order. Use the native-endian versions when working with values
+// that were always in memory, such as when stored in shared-memory (or through
+// IPC) as a byte buffer.
+inline constexpr double DoubleFromBigEndian(
+    std::span<const uint8_t, 8u> bytes) {
+  return std::bit_cast<double>(U64FromBigEndian(bytes));
+}
+
+// Returns a byte array holding the value of a uint8_t encoded as the native
+// endian encoding of the integer for the machine.
+//
+// This is suitable for encoding integers that will always be kept in native
+// encoding, such as for storing in shared-memory (or sending through IPC) as a
+// byte buffer. Prefer an explicit little endian when storing data into external
+// storage, and explicit big endian for network order.
+inline constexpr std::array<uint8_t, 1u> U8ToNativeEndian(uint8_t val) {
+  return {val};
+}
+// Returns a byte array holding the value of a uint16_t encoded as the native
+// endian encoding of the integer for the machine.
+//
+// This is suitable for encoding integers that will always be kept in native
+// encoding, such as for storing in shared-memory (or sending through IPC) as a
+// byte buffer. Prefer an explicit little endian when storing data into external
+// storage, and explicit big endian for network order.
+inline constexpr std::array<uint8_t, 2u> U16ToNativeEndian(uint16_t val) {
+  return internal::ToLittleEndian(val);
+}
+// Returns a byte array holding the value of a uint32_t encoded as the native
+// endian encoding of the integer for the machine.
+//
+// This is suitable for encoding integers that will always be kept in native
+// encoding, such as for storing in shared-memory (or sending through IPC) as a
+// byte buffer. Prefer an explicit little endian when storing data into external
+// storage, and explicit big endian for network order.
+inline constexpr std::array<uint8_t, 4u> U32ToNativeEndian(uint32_t val) {
+  return internal::ToLittleEndian(val);
+}
+// Returns a byte array holding the value of a uint64_t encoded as the native
+// endian encoding of the integer for the machine.
+//
+// This is suitable for encoding integers that will always be kept in native
+// encoding, such as for storing in shared-memory (or sending through IPC) as a
+// byte buffer. Prefer an explicit little endian when storing data into external
+// storage, and explicit big endian for network order.
+inline constexpr std::array<uint8_t, 8u> U64ToNativeEndian(uint64_t val) {
+  return internal::ToLittleEndian(val);
+}
+// Returns a byte array holding the value of a int8_t encoded as the native
+// endian encoding of the integer for the machine.
+//
+// This is suitable for encoding integers that will always be kept in native
+// encoding, such as for storing in shared-memory (or sending through IPC) as a
+// byte buffer. Prefer an explicit little endian when storing data into external
+// storage, and explicit big endian for network order.
+inline constexpr std::array<uint8_t, 1u> I8ToNativeEndian(int8_t val) {
+  return {static_cast<uint8_t>(val)};
+}
+// Returns a byte array holding the value of a int16_t encoded as the native
+// endian encoding of the integer for the machine.
+//
+// This is suitable for encoding integers that will always be kept in native
+// encoding, such as for storing in shared-memory (or sending through IPC) as a
+// byte buffer. Prefer an explicit little endian when storing data into external
+// storage, and explicit big endian for network order.
+inline constexpr std::array<uint8_t, 2u> I16ToNativeEndian(int16_t val) {
+  return internal::ToLittleEndian(val);
+}
+// Returns a byte array holding the value of a int32_t encoded as the native
+// endian encoding of the integer for the machine.
+//
+// This is suitable for encoding integers that will always be kept in native
+// encoding, such as for storing in shared-memory (or sending through IPC) as a
+// byte buffer. Prefer an explicit little endian when storing data into external
+// storage, and explicit big endian for network order.
+inline constexpr std::array<uint8_t, 4u> I32ToNativeEndian(int32_t val) {
+  return internal::ToLittleEndian(val);
+}
+// Returns a byte array holding the value of a int64_t encoded as the native
+// endian encoding of the integer for the machine.
+//
+// This is suitable for encoding integers that will always be kept in native
+// encoding, such as for storing in shared-memory (or sending through IPC) as a
+// byte buffer. Prefer an explicit little endian when storing data into external
+// storage, and explicit big endian for network order.
+inline constexpr std::array<uint8_t, 8u> I64ToNativeEndian(int64_t val) {
+  return internal::ToLittleEndian(val);
+}
+// Returns a byte array holding the value of a float encoded as the native
+// endian encoding of the number for the machine.
+//
+// This is suitable for encoding numbers that will always be kept in native
+// encoding, such as for storing in shared-memory (or sending through IPC) as a
+// byte buffer. Prefer an explicit little endian when storing data into external
+// storage, and explicit big endian for network order.
+inline constexpr std::array<uint8_t, 4u> FloatToNativeEndian(float val) {
+  return U32ToNativeEndian(std::bit_cast<uint32_t>(val));
+}
+// Returns a byte array holding the value of a double encoded as the native
+// endian encoding of the number for the machine.
+//
+// This is suitable for encoding numbers that will always be kept in native
+// encoding, such as for storing in shared-memory (or sending through IPC) as a
+// byte buffer. Prefer an explicit little endian when storing data into external
+// storage, and explicit big endian for network order.
+inline constexpr std::array<uint8_t, 8u> DoubleToNativeEndian(double val) {
+  return U64ToNativeEndian(std::bit_cast<uint64_t>(val));
+}
+
+// Returns a byte array holding the value of a uint8_t encoded as the
+// little-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in little endian, which is
+// a good practice with storing and reading data from storage. Use the
+// native-endian versions when working with values that will always be in
+// memory, such as when stored in shared-memory (or passed through IPC) as a
+// byte buffer.
+inline constexpr std::array<uint8_t, 1u> U8ToLittleEndian(uint8_t val) {
+  return {val};
+}
+// Returns a byte array holding the value of a uint16_t encoded as the
+// little-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in little endian, which is
+// a good practice with storing and reading data from storage. Use the
+// native-endian versions when working with values that will always be in
+// memory, such as when stored in shared-memory (or passed through IPC) as a
+// byte buffer.
+inline constexpr std::array<uint8_t, 2u> U16ToLittleEndian(uint16_t val) {
+  return internal::ToLittleEndian(val);
+}
+// Returns a byte array holding the value of a uint32_t encoded as the
+// little-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in little endian, which is
+// a good practice with storing and reading data from storage. Use the
+// native-endian versions when working with values that will always be in
+// memory, such as when stored in shared-memory (or passed through IPC) as a
+// byte buffer.
+inline constexpr std::array<uint8_t, 4u> U32ToLittleEndian(uint32_t val) {
+  return internal::ToLittleEndian(val);
+}
+// Returns a byte array holding the value of a uint64_t encoded as the
+// little-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in little endian, which is
+// a good practice with storing and reading data from storage. Use the
+// native-endian versions when working with values that will always be in
+// memory, such as when stored in shared-memory (or passed through IPC) as a
+// byte buffer.
+inline constexpr std::array<uint8_t, 8u> U64ToLittleEndian(uint64_t val) {
+  return internal::ToLittleEndian(val);
+}
+// Returns a byte array holding the value of a int8_t encoded as the
+// little-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in little endian, which is
+// a good practice with storing and reading data from storage. Use the
+// native-endian versions when working with values that will always be in
+// memory, such as when stored in shared-memory (or passed through IPC) as a
+// byte buffer.
+inline constexpr std::array<uint8_t, 1u> I8ToLittleEndian(int8_t val) {
+  return {static_cast<uint8_t>(val)};
+}
+// Returns a byte array holding the value of a int16_t encoded as the
+// little-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in little endian, which is
+// a good practice with storing and reading data from storage. Use the
+// native-endian versions when working with values that will always be in
+// memory, such as when stored in shared-memory (or passed through IPC) as a
+// byte buffer.
+inline constexpr std::array<uint8_t, 2u> I16ToLittleEndian(int16_t val) {
+  return internal::ToLittleEndian(val);
+}
+// Returns a byte array holding the value of a int32_t encoded as the
+// little-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in little endian, which is
+// a good practice with storing and reading data from storage. Use the
+// native-endian versions when working with values that will always be in
+// memory, such as when stored in shared-memory (or passed through IPC) as a
+// byte buffer.
+inline constexpr std::array<uint8_t, 4u> I32ToLittleEndian(int32_t val) {
+  return internal::ToLittleEndian(val);
+}
+// Returns a byte array holding the value of a int64_t encoded as the
+// little-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in little endian, which is
+// a good practice with storing and reading data from storage. Use the
+// native-endian versions when working with values that will always be in
+// memory, such as when stored in shared-memory (or passed through IPC) as a
+// byte buffer.
+inline constexpr std::array<uint8_t, 8u> I64ToLittleEndian(int64_t val) {
+  return internal::ToLittleEndian(val);
+}
+// Returns a byte array holding the value of a float encoded as the
+// little-endian encoding of the number.
+//
+// This is suitable for encoding numbers explicitly in little endian, which is
+// a good practice with storing and reading data from storage. Use the
+// native-endian versions when working with values that will always be in
+// memory, such as when stored in shared-memory (or passed through IPC) as a
+// byte buffer.
+inline constexpr std::array<uint8_t, 4u> FloatToLittleEndian(float val) {
+  return internal::ToLittleEndian(std::bit_cast<uint32_t>(val));
+}
+// Returns a byte array holding the value of a double encoded as the
+// little-endian encoding of the number.
+//
+// This is suitable for encoding numbers explicitly in little endian, which is
+// a good practice with storing and reading data from storage. Use the
+// native-endian versions when working with values that will always be in
+// memory, such as when stored in shared-memory (or passed through IPC) as a
+// byte buffer.
+inline constexpr std::array<uint8_t, 8u> DoubleToLittleEndian(double val) {
+  return internal::ToLittleEndian(std::bit_cast<uint64_t>(val));
+}
+
+// Returns a byte array holding the value of a uint8_t encoded as the big-endian
+// encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in big endian, such as for
+// network order. Use the native-endian versions when working with values that
+// are always in memory, such as when stored in shared-memory (or passed through
+// IPC) as a byte buffer. Use the little-endian encoding for storing and reading
+// from storage.
+inline constexpr std::array<uint8_t, 1u> U8ToBigEndian(uint8_t val) {
+  return {val};
+}
+// Returns a byte array holding the value of a uint16_t encoded as the
+// big-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in big endian, such as for
+// network order. Use the native-endian versions when working with values that
+// are always in memory, such as when stored in shared-memory (or passed through
+// IPC) as a byte buffer. Use the little-endian encoding for storing and reading
+// from storage.
+inline constexpr std::array<uint8_t, 2u> U16ToBigEndian(uint16_t val) {
+  return internal::ToLittleEndian(ByteSwap(val));
+}
+// Returns a byte array holding the value of a uint32_t encoded as the
+// big-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in big endian, such as for
+// network order. Use the native-endian versions when working with values that
+// are always in memory, such as when stored in shared-memory (or passed through
+// IPC) as a byte buffer. Use the little-endian encoding for storing and reading
+// from storage.
+inline constexpr std::array<uint8_t, 4u> U32ToBigEndian(uint32_t val) {
+  return internal::ToLittleEndian(ByteSwap(val));
+}
+// Returns a byte array holding the value of a uint64_t encoded as the
+// big-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in big endian, such as for
+// network order. Use the native-endian versions when working with values that
+// are always in memory, such as when stored in shared-memory (or passed through
+// IPC) as a byte buffer. Use the little-endian encoding for storing and reading
+// from storage.
+inline constexpr std::array<uint8_t, 8u> U64ToBigEndian(uint64_t val) {
+  return internal::ToLittleEndian(ByteSwap(val));
+}
+// Returns a byte array holding the value of a int8_t encoded as the big-endian
+// encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in big endian, such as for
+// network order. Use the native-endian versions when working with values that
+// are always in memory, such as when stored in shared-memory (or passed through
+// IPC) as a byte buffer. Use the little-endian encoding for storing and reading
+// from storage.
+inline constexpr std::array<uint8_t, 1u> I8ToBigEndian(int8_t val) {
+  return {static_cast<uint8_t>(val)};
+}
+// Returns a byte array holding the value of a int16_t encoded as the
+// big-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in big endian, such as for
+// network order. Use the native-endian versions when working with values that
+// are always in memory, such as when stored in shared-memory (or passed through
+// IPC) as a byte buffer. Use the little-endian encoding for storing and reading
+// from storage.
+inline constexpr std::array<uint8_t, 2u> I16ToBigEndian(int16_t val) {
+  return internal::ToLittleEndian(ByteSwap(val));
+}
+// Returns a byte array holding the value of a int32_t encoded as the
+// big-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in big endian, such as for
+// network order. Use the native-endian versions when working with values that
+// are always in memory, such as when stored in shared-memory (or passed through
+// IPC) as a byte buffer. Use the little-endian encoding for storing and reading
+// from storage.
+inline constexpr std::array<uint8_t, 4u> I32ToBigEndian(int32_t val) {
+  return internal::ToLittleEndian(ByteSwap(val));
+}
+// Returns a byte array holding the value of a int64_t encoded as the
+// big-endian encoding of the integer.
+//
+// This is suitable for encoding integers explicitly in big endian, such as for
+// network order. Use the native-endian versions when working with values that
+// are always in memory, such as when stored in shared-memory (or passed through
+// IPC) as a byte buffer. Use the little-endian encoding for storing and reading
+// from storage.
+inline constexpr std::array<uint8_t, 8u> I64ToBigEndian(int64_t val) {
+  return internal::ToLittleEndian(ByteSwap(val));
+}
+// Returns a byte array holding the value of a float encoded as the big-endian
+// encoding of the number.
+//
+// This is suitable for encoding numbers explicitly in big endian, such as for
+// network order. Use the native-endian versions when working with values that
+// are always in memory, such as when stored in shared-memory (or passed through
+// IPC) as a byte buffer. Use the little-endian encoding for storing and reading
+// from storage.
+inline constexpr std::array<uint8_t, 4u> FloatToBigEndian(float val) {
+  return internal::ToLittleEndian(ByteSwap(std::bit_cast<uint32_t>(val)));
+}
+// Returns a byte array holding the value of a double encoded as the big-endian
+// encoding of the number.
+//
+// This is suitable for encoding numbers explicitly in big endian, such as for
+// network order. Use the native-endian versions when working with values that
+// are always in memory, such as when stored in shared-memory (or passed through
+// IPC) as a byte buffer. Use the little-endian encoding for storing and reading
+// from storage.
+inline constexpr std::array<uint8_t, 8u> DoubleToBigEndian(double val) {
+  return internal::ToLittleEndian(ByteSwap(std::bit_cast<uint64_t>(val)));
+}
+
+// Deprecated: Prefer the shorter, less-namespaced names.
+// TODO(crbug.com/40284755): Remove these when callers have been migrated to
+// the shorter name.
+namespace numerics {
+using ::base::ByteSwap;
+using ::base::DoubleFromBigEndian;
+using ::base::DoubleFromLittleEndian;
+using ::base::DoubleFromNativeEndian;
+using ::base::DoubleToBigEndian;
+using ::base::DoubleToLittleEndian;
+using ::base::DoubleToNativeEndian;
+using ::base::FloatFromBigEndian;
+using ::base::FloatFromLittleEndian;
+using ::base::FloatFromNativeEndian;
+using ::base::FloatToBigEndian;
+using ::base::FloatToLittleEndian;
+using ::base::FloatToNativeEndian;
+using ::base::I16FromBigEndian;
+using ::base::I16FromLittleEndian;
+using ::base::I16FromNativeEndian;
+using ::base::I16ToBigEndian;
+using ::base::I16ToLittleEndian;
+using ::base::I16ToNativeEndian;
+using ::base::I32FromBigEndian;
+using ::base::I32FromLittleEndian;
+using ::base::I32FromNativeEndian;
+using ::base::I32ToBigEndian;
+using ::base::I32ToLittleEndian;
+using ::base::I32ToNativeEndian;
+using ::base::I64FromBigEndian;
+using ::base::I64FromLittleEndian;
+using ::base::I64FromNativeEndian;
+using ::base::I64ToBigEndian;
+using ::base::I64ToLittleEndian;
+using ::base::I64ToNativeEndian;
+using ::base::I8FromBigEndian;
+using ::base::I8FromLittleEndian;
+using ::base::I8FromNativeEndian;
+using ::base::I8ToBigEndian;
+using ::base::I8ToLittleEndian;
+using ::base::I8ToNativeEndian;
+using ::base::U16FromBigEndian;
+using ::base::U16FromLittleEndian;
+using ::base::U16FromNativeEndian;
+using ::base::U16ToBigEndian;
+using ::base::U16ToLittleEndian;
+using ::base::U16ToNativeEndian;
+using ::base::U32FromBigEndian;
+using ::base::U32FromLittleEndian;
+using ::base::U32FromNativeEndian;
+using ::base::U32ToBigEndian;
+using ::base::U32ToLittleEndian;
+using ::base::U32ToNativeEndian;
+using ::base::U64FromBigEndian;
+using ::base::U64FromLittleEndian;
+using ::base::U64FromNativeEndian;
+using ::base::U64ToBigEndian;
+using ::base::U64ToLittleEndian;
+using ::base::U64ToNativeEndian;
+using ::base::U8FromBigEndian;
+using ::base::U8FromLittleEndian;
+using ::base::U8FromNativeEndian;
+using ::base::U8ToBigEndian;
+using ::base::U8ToLittleEndian;
+using ::base::U8ToNativeEndian;
+}  // namespace numerics
+
+}  // namespace base
+
+#endif  //  THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_BYTE_CONVERSIONS_H_

--- a/internal/base/numerics/checked_math.h
+++ b/internal/base/numerics/checked_math.h
@@ -1,0 +1,381 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_CHECKED_MATH_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_CHECKED_MATH_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include <stdint.h>
+#include <limits>
+#include <type_traits>
+
+#include "internal/base/numerics/checked_math_impl.h"  // IWYU pragma: export
+#include "internal/base/numerics/safe_conversions.h"
+#include "internal/base/numerics/safe_math_shared_impl.h"  // IWYU pragma: export
+
+namespace base {
+namespace internal {
+
+template <typename T>
+class CheckedNumeric {
+  static_assert(std::is_arithmetic_v<T>,
+                "CheckedNumeric<T>: T must be a numeric type.");
+
+ public:
+  template <typename Src>
+  friend class CheckedNumeric;
+
+  using type = T;
+
+  constexpr CheckedNumeric() = default;
+
+  // Copy constructor.
+  template <typename Src>
+  constexpr CheckedNumeric(const CheckedNumeric<Src>& rhs)
+      : state_(rhs.state_.value(), rhs.IsValid()) {}
+
+  // Strictly speaking, this is not necessary, but declaring this allows class
+  // template argument deduction to be used so that it is possible to simply
+  // write `CheckedNumeric(777)` instead of `CheckedNumeric<int>(777)`.
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr CheckedNumeric(T value) : state_(value) {}
+
+  // This is not an explicit constructor because we implicitly upgrade regular
+  // numerics to CheckedNumerics to make them easier to use.
+  template <typename Src>
+    requires(std::is_arithmetic_v<Src>)
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr CheckedNumeric(Src value) : state_(value) {}
+
+  // This is not an explicit constructor because we want a seamless conversion
+  // from StrictNumeric types.
+  template <typename Src>
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr CheckedNumeric(StrictNumeric<Src> value)
+      : state_(static_cast<Src>(value)) {}
+
+  // IsValid() - The public API to test if a CheckedNumeric is currently valid.
+  // A range checked destination type can be supplied using the Dst template
+  // parameter.
+  template <typename Dst = T>
+  constexpr bool IsValid() const {
+    return state_.is_valid() &&
+           IsValueInRangeForNumericType<Dst>(state_.value());
+  }
+
+  // AssignIfValid(Dst) - Assigns the underlying value if it is currently valid
+  // and is within the range supported by the destination type. Returns true if
+  // successful and false otherwise.
+  template <typename Dst>
+#if defined(__clang__) || defined(__GNUC__)
+  __attribute__((warn_unused_result))
+#elif defined(_MSC_VER)
+  _Check_return_
+#endif
+  constexpr bool
+  AssignIfValid(Dst* result) const {
+    return BASE_NUMERICS_LIKELY(IsValid<Dst>())
+               ? ((*result = static_cast<Dst>(state_.value())), true)
+               : false;
+  }
+
+  // ValueOrDie() - The primary accessor for the underlying value. If the
+  // current state is not valid it will CHECK and crash.
+  // A range checked destination type can be supplied using the Dst template
+  // parameter, which will trigger a CHECK if the value is not in bounds for
+  // the destination.
+  // The CHECK behavior can be overridden by supplying a handler as a
+  // template parameter, for test code, etc. However, the handler cannot access
+  // the underlying value, and it is not available through other means.
+  template <typename Dst = T, class CheckHandler = CheckOnFailure>
+  constexpr StrictNumeric<Dst> ValueOrDie() const {
+    return BASE_NUMERICS_LIKELY(IsValid<Dst>())
+               ? static_cast<Dst>(state_.value())
+               : CheckHandler::template HandleFailure<Dst>();
+  }
+
+  // ValueOrDefault(T default_value) - A convenience method that returns the
+  // current value if the state is valid, and the supplied default_value for
+  // any other state.
+  // A range checked destination type can be supplied using the Dst template
+  // parameter. WARNING: This function may fail to compile or CHECK at runtime
+  // if the supplied default_value is not within range of the destination type.
+  template <typename Dst = T, typename Src>
+  constexpr StrictNumeric<Dst> ValueOrDefault(const Src default_value) const {
+    return BASE_NUMERICS_LIKELY(IsValid<Dst>())
+               ? static_cast<Dst>(state_.value())
+               : checked_cast<Dst>(default_value);
+  }
+
+  // Returns a checked numeric of the specified type, cast from the current
+  // CheckedNumeric. If the current state is invalid or the destination cannot
+  // represent the result then the returned CheckedNumeric will be invalid.
+  template <typename Dst>
+  constexpr CheckedNumeric<typename UnderlyingType<Dst>::type> Cast() const {
+    return *this;
+  }
+
+  // This friend method is available solely for providing more detailed logging
+  // in the tests. Do not implement it in production code, because the
+  // underlying values may change at any time.
+  template <typename U>
+  friend U GetNumericValueForTest(const CheckedNumeric<U>& src);
+
+  // Prototypes for the supported arithmetic operator overloads.
+  template <typename Src>
+  constexpr CheckedNumeric& operator+=(const Src rhs);
+  template <typename Src>
+  constexpr CheckedNumeric& operator-=(const Src rhs);
+  template <typename Src>
+  constexpr CheckedNumeric& operator*=(const Src rhs);
+  template <typename Src>
+  constexpr CheckedNumeric& operator/=(const Src rhs);
+  template <typename Src>
+  constexpr CheckedNumeric& operator%=(const Src rhs);
+  template <typename Src>
+  constexpr CheckedNumeric& operator<<=(const Src rhs);
+  template <typename Src>
+  constexpr CheckedNumeric& operator>>=(const Src rhs);
+  template <typename Src>
+  constexpr CheckedNumeric& operator&=(const Src rhs);
+  template <typename Src>
+  constexpr CheckedNumeric& operator|=(const Src rhs);
+  template <typename Src>
+  constexpr CheckedNumeric& operator^=(const Src rhs);
+
+  constexpr CheckedNumeric operator-() const {
+    // Use an optimized code path for a known run-time variable.
+    if (!IsConstantEvaluated() && std::is_signed_v<T> &&
+        std::is_floating_point_v<T>) {
+      return FastRuntimeNegate();
+    }
+    // The negation of two's complement int min is int min.
+    const bool is_valid =
+        IsValid() &&
+        (!std::is_signed_v<T> || std::is_floating_point_v<T> ||
+         NegateWrapper(state_.value()) != std::numeric_limits<T>::lowest());
+    return CheckedNumeric<T>(NegateWrapper(state_.value()), is_valid);
+  }
+
+  constexpr CheckedNumeric operator~() const {
+    return CheckedNumeric<decltype(InvertWrapper(T()))>(
+        InvertWrapper(state_.value()), IsValid());
+  }
+
+  constexpr CheckedNumeric Abs() const {
+    return !IsValueNegative(state_.value()) ? *this : -*this;
+  }
+
+  template <typename U>
+  constexpr CheckedNumeric<typename MathWrapper<CheckedMaxOp, T, U>::type> Max(
+      const U rhs) const {
+    return CheckMax(*this, rhs);
+  }
+
+  template <typename U>
+  constexpr CheckedNumeric<typename MathWrapper<CheckedMinOp, T, U>::type> Min(
+      const U rhs) const {
+    return CheckMin(*this, rhs);
+  }
+
+  // This function is available only for integral types. It returns an unsigned
+  // integer of the same width as the source type, containing the absolute value
+  // of the source, and properly handling signed min.
+  constexpr CheckedNumeric<typename UnsignedOrFloatForSize<T>::type>
+  UnsignedAbs() const {
+    return CheckedNumeric<typename UnsignedOrFloatForSize<T>::type>(
+        SafeUnsignedAbs(state_.value()), state_.is_valid());
+  }
+
+  constexpr CheckedNumeric& operator++() {
+    *this += 1;
+    return *this;
+  }
+
+  constexpr CheckedNumeric operator++(int) {
+    CheckedNumeric value = *this;
+    *this += 1;
+    return value;
+  }
+
+  constexpr CheckedNumeric& operator--() {
+    *this -= 1;
+    return *this;
+  }
+
+  constexpr CheckedNumeric operator--(int) {
+    // TODO(pkasting): Consider std::exchange() once it's constexpr in C++20.
+    const CheckedNumeric value = *this;
+    *this -= 1;
+    return value;
+  }
+
+  // These perform the actual math operations on the CheckedNumerics.
+  // Binary arithmetic operations.
+  template <template <typename, typename> class M, typename L, typename R>
+  static constexpr CheckedNumeric MathOp(const L lhs, const R rhs) {
+    using Math = typename MathWrapper<M, L, R>::math;
+    T result = 0;
+    const bool is_valid =
+        Wrapper<L>::is_valid(lhs) && Wrapper<R>::is_valid(rhs) &&
+        Math::Do(Wrapper<L>::value(lhs), Wrapper<R>::value(rhs), &result);
+    return CheckedNumeric<T>(result, is_valid);
+  }
+
+  // Assignment arithmetic operations.
+  template <template <typename, typename> class M, typename R>
+  constexpr CheckedNumeric& MathOp(const R rhs) {
+    using Math = typename MathWrapper<M, T, R>::math;
+    T result = 0;  // Using T as the destination saves a range check.
+    const bool is_valid =
+        state_.is_valid() && Wrapper<R>::is_valid(rhs) &&
+        Math::Do(state_.value(), Wrapper<R>::value(rhs), &result);
+    *this = CheckedNumeric<T>(result, is_valid);
+    return *this;
+  }
+
+ private:
+  CheckedNumericState<T> state_;
+
+  CheckedNumeric FastRuntimeNegate() const {
+    T result;
+    const bool success = CheckedSubOp<T, T>::Do(T(0), state_.value(), &result);
+    return CheckedNumeric<T>(result, IsValid() && success);
+  }
+
+  template <typename Src>
+  constexpr CheckedNumeric(Src value, bool is_valid)
+      : state_(value, is_valid) {}
+
+  // These wrappers allow us to handle state the same way for both
+  // CheckedNumeric and POD arithmetic types.
+  template <typename Src>
+  struct Wrapper {
+    static constexpr bool is_valid(Src) { return true; }
+    static constexpr Src value(Src value) { return value; }
+  };
+
+  template <typename Src>
+  struct Wrapper<CheckedNumeric<Src>> {
+    static constexpr bool is_valid(const CheckedNumeric<Src> v) {
+      return v.IsValid();
+    }
+    static constexpr Src value(const CheckedNumeric<Src> v) {
+      return v.state_.value();
+    }
+  };
+
+  template <typename Src>
+  struct Wrapper<StrictNumeric<Src>> {
+    static constexpr bool is_valid(const StrictNumeric<Src>) { return true; }
+    static constexpr Src value(const StrictNumeric<Src> v) {
+      return static_cast<Src>(v);
+    }
+  };
+};
+
+// Convenience functions to avoid the ugly template disambiguator syntax.
+template <typename Dst, typename Src>
+constexpr bool IsValidForType(const CheckedNumeric<Src> value) {
+  return value.template IsValid<Dst>();
+}
+
+template <typename Dst, typename Src>
+constexpr StrictNumeric<Dst> ValueOrDieForType(
+    const CheckedNumeric<Src> value) {
+  return value.template ValueOrDie<Dst>();
+}
+
+template <typename Dst, typename Src, typename Default>
+constexpr StrictNumeric<Dst> ValueOrDefaultForType(
+    const CheckedNumeric<Src> value,
+    const Default default_value) {
+  return value.template ValueOrDefault<Dst>(default_value);
+}
+
+// Convenience wrapper to return a new CheckedNumeric from the provided
+// arithmetic or CheckedNumericType.
+template <typename T>
+constexpr CheckedNumeric<typename UnderlyingType<T>::type> MakeCheckedNum(
+    const T value) {
+  return value;
+}
+
+// These implement the variadic wrapper for the math operations.
+template <template <typename, typename> class M, typename L, typename R>
+constexpr CheckedNumeric<typename MathWrapper<M, L, R>::type> CheckMathOp(
+    const L lhs,
+    const R rhs) {
+  using Math = typename MathWrapper<M, L, R>::math;
+  return CheckedNumeric<typename Math::result_type>::template MathOp<M>(lhs,
+                                                                        rhs);
+}
+
+// General purpose wrapper template for arithmetic operations.
+template <template <typename, typename> class M,
+          typename L,
+          typename R,
+          typename... Args>
+constexpr auto CheckMathOp(const L lhs, const R rhs, const Args... args) {
+  return CheckMathOp<M>(CheckMathOp<M>(lhs, rhs), args...);
+}
+
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Checked, Check, Add, +, +=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Checked, Check, Sub, -, -=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Checked, Check, Mul, *, *=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Checked, Check, Div, /, /=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Checked, Check, Mod, %, %=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Checked, Check, Lsh, <<, <<=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Checked, Check, Rsh, >>, >>=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Checked, Check, And, &, &=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Checked, Check, Or, |, |=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Checked, Check, Xor, ^, ^=)
+BASE_NUMERIC_ARITHMETIC_VARIADIC(Checked, Check, Max)
+BASE_NUMERIC_ARITHMETIC_VARIADIC(Checked, Check, Min)
+
+// These are some extra StrictNumeric operators to support simple pointer
+// arithmetic with our result types. Since wrapping on a pointer is always
+// bad, we trigger the CHECK condition here.
+template <typename L, typename R>
+L* operator+(L* lhs, const StrictNumeric<R> rhs) {
+  const uintptr_t result = CheckAdd(reinterpret_cast<uintptr_t>(lhs),
+                                    CheckMul(sizeof(L), static_cast<R>(rhs)))
+                               .template ValueOrDie<uintptr_t>();
+  return reinterpret_cast<L*>(result);
+}
+
+template <typename L, typename R>
+L* operator-(L* lhs, const StrictNumeric<R> rhs) {
+  const uintptr_t result = CheckSub(reinterpret_cast<uintptr_t>(lhs),
+                                    CheckMul(sizeof(L), static_cast<R>(rhs)))
+                               .template ValueOrDie<uintptr_t>();
+  return reinterpret_cast<L*>(result);
+}
+
+}  // namespace internal
+
+using internal::CheckAdd;
+using internal::CheckAnd;
+using internal::CheckDiv;
+using internal::CheckedNumeric;
+using internal::CheckLsh;
+using internal::CheckMax;
+using internal::CheckMin;
+using internal::CheckMod;
+using internal::CheckMul;
+using internal::CheckOr;
+using internal::CheckRsh;
+using internal::CheckSub;
+using internal::CheckXor;
+using internal::IsValidForType;
+using internal::MakeCheckedNum;
+using internal::ValueOrDefaultForType;
+using internal::ValueOrDieForType;
+
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_CHECKED_MATH_H_

--- a/internal/base/numerics/checked_math_impl.h
+++ b/internal/base/numerics/checked_math_impl.h
@@ -1,0 +1,572 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_CHECKED_MATH_IMPL_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_CHECKED_MATH_IMPL_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+// IWYU pragma: private, include "base/numerics/checked_math.h"
+
+#include <stdint.h>
+
+#include <cmath>
+#include <concepts>
+#include <limits>
+#include <type_traits>
+
+#include "internal/base/numerics/safe_conversions.h"
+#include "internal/base/numerics/safe_math_shared_impl.h"  // IWYU pragma: export
+
+namespace base {
+namespace internal {
+
+template <typename T>
+constexpr bool CheckedAddImpl(T x, T y, T* result) {
+  static_assert(std::is_integral_v<T>, "Type must be integral");
+  // Since the value of x+y is undefined if we have a signed type, we compute
+  // it using the unsigned type of the same size.
+  using UnsignedDst = typename std::make_unsigned<T>::type;
+  using SignedDst = typename std::make_signed<T>::type;
+  const UnsignedDst ux = static_cast<UnsignedDst>(x);
+  const UnsignedDst uy = static_cast<UnsignedDst>(y);
+  const UnsignedDst uresult = static_cast<UnsignedDst>(ux + uy);
+  // Addition is valid if the sign of (x + y) is equal to either that of x or
+  // that of y.
+  if (std::is_signed_v<T>
+          ? static_cast<SignedDst>((uresult ^ ux) & (uresult ^ uy)) < 0
+          : uresult < uy) {  // Unsigned is either valid or underflow.
+    return false;
+  }
+  *result = static_cast<T>(uresult);
+  return true;
+}
+
+template <typename T, typename U>
+struct CheckedAddOp {};
+
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct CheckedAddOp<T, U> {
+  using result_type = typename MaxExponentPromotion<T, U>::type;
+  template <typename V>
+  static constexpr bool Do(T x, U y, V* result) {
+    if constexpr (CheckedAddFastOp<T, U>::is_supported)
+      return CheckedAddFastOp<T, U>::Do(x, y, result);
+
+    // Double the underlying type up to a full machine word.
+    using FastPromotion = typename FastIntegerArithmeticPromotion<T, U>::type;
+    using Promotion =
+        typename std::conditional<(IntegerBitsPlusSign<FastPromotion>::value >
+                                   IntegerBitsPlusSign<intptr_t>::value),
+                                  typename BigEnoughPromotion<T, U>::type,
+                                  FastPromotion>::type;
+    // Fail if either operand is out of range for the promoted type.
+    // TODO(jschuh): This could be made to work for a broader range of values.
+    if (BASE_NUMERICS_UNLIKELY(!IsValueInRangeForNumericType<Promotion>(x) ||
+                               !IsValueInRangeForNumericType<Promotion>(y))) {
+      return false;
+    }
+
+    Promotion presult = {};
+    bool is_valid = true;
+    if (IsIntegerArithmeticSafe<Promotion, T, U>::value) {
+      presult = static_cast<Promotion>(x) + static_cast<Promotion>(y);
+    } else {
+      is_valid = CheckedAddImpl(static_cast<Promotion>(x),
+                                static_cast<Promotion>(y), &presult);
+    }
+    if (!is_valid || !IsValueInRangeForNumericType<V>(presult))
+      return false;
+    *result = static_cast<V>(presult);
+    return true;
+  }
+};
+
+template <typename T>
+constexpr bool CheckedSubImpl(T x, T y, T* result) {
+  static_assert(std::is_integral_v<T>, "Type must be integral");
+  // Since the value of x+y is undefined if we have a signed type, we compute
+  // it using the unsigned type of the same size.
+  using UnsignedDst = typename std::make_unsigned<T>::type;
+  using SignedDst = typename std::make_signed<T>::type;
+  const UnsignedDst ux = static_cast<UnsignedDst>(x);
+  const UnsignedDst uy = static_cast<UnsignedDst>(y);
+  const UnsignedDst uresult = static_cast<UnsignedDst>(ux - uy);
+  // Subtraction is valid if either x and y have same sign, or (x-y) and x have
+  // the same sign.
+  if (std::is_signed_v<T>
+          ? static_cast<SignedDst>((uresult ^ ux) & (ux ^ uy)) < 0
+          : x < y) {
+    return false;
+  }
+  *result = static_cast<T>(uresult);
+  return true;
+}
+
+template <typename T, typename U>
+struct CheckedSubOp {};
+
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct CheckedSubOp<T, U> {
+  using result_type = typename MaxExponentPromotion<T, U>::type;
+  template <typename V>
+  static constexpr bool Do(T x, U y, V* result) {
+    if constexpr (CheckedSubFastOp<T, U>::is_supported)
+      return CheckedSubFastOp<T, U>::Do(x, y, result);
+
+    // Double the underlying type up to a full machine word.
+    using FastPromotion = typename FastIntegerArithmeticPromotion<T, U>::type;
+    using Promotion =
+        typename std::conditional<(IntegerBitsPlusSign<FastPromotion>::value >
+                                   IntegerBitsPlusSign<intptr_t>::value),
+                                  typename BigEnoughPromotion<T, U>::type,
+                                  FastPromotion>::type;
+    // Fail if either operand is out of range for the promoted type.
+    // TODO(jschuh): This could be made to work for a broader range of values.
+    if (BASE_NUMERICS_UNLIKELY(!IsValueInRangeForNumericType<Promotion>(x) ||
+                               !IsValueInRangeForNumericType<Promotion>(y))) {
+      return false;
+    }
+
+    Promotion presult = {};
+    bool is_valid = true;
+    if (IsIntegerArithmeticSafe<Promotion, T, U>::value) {
+      presult = static_cast<Promotion>(x) - static_cast<Promotion>(y);
+    } else {
+      is_valid = CheckedSubImpl(static_cast<Promotion>(x),
+                                static_cast<Promotion>(y), &presult);
+    }
+    if (!is_valid || !IsValueInRangeForNumericType<V>(presult))
+      return false;
+    *result = static_cast<V>(presult);
+    return true;
+  }
+};
+
+template <typename T>
+constexpr bool CheckedMulImpl(T x, T y, T* result) {
+  static_assert(std::is_integral_v<T>, "Type must be integral");
+  // Since the value of x*y is potentially undefined if we have a signed type,
+  // we compute it using the unsigned type of the same size.
+  using UnsignedDst = typename std::make_unsigned<T>::type;
+  using SignedDst = typename std::make_signed<T>::type;
+  const UnsignedDst ux = SafeUnsignedAbs(x);
+  const UnsignedDst uy = SafeUnsignedAbs(y);
+  const UnsignedDst uresult = static_cast<UnsignedDst>(ux * uy);
+  const bool is_negative =
+      std::is_signed_v<T> && static_cast<SignedDst>(x ^ y) < 0;
+  // We have a fast out for unsigned identity or zero on the second operand.
+  // After that it's an unsigned overflow check on the absolute value, with
+  // a +1 bound for a negative result.
+  if (uy > UnsignedDst(!std::is_signed_v<T> || is_negative) &&
+      ux > (std::numeric_limits<T>::max() + UnsignedDst(is_negative)) / uy) {
+    return false;
+  }
+  *result = static_cast<T>(is_negative ? 0 - uresult : uresult);
+  return true;
+}
+
+template <typename T, typename U>
+struct CheckedMulOp {};
+
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct CheckedMulOp<T, U> {
+  using result_type = typename MaxExponentPromotion<T, U>::type;
+  template <typename V>
+  static constexpr bool Do(T x, U y, V* result) {
+    if constexpr (CheckedMulFastOp<T, U>::is_supported)
+      return CheckedMulFastOp<T, U>::Do(x, y, result);
+
+    using Promotion = typename FastIntegerArithmeticPromotion<T, U>::type;
+    // Verify the destination type can hold the result (always true for 0).
+    if (BASE_NUMERICS_UNLIKELY((!IsValueInRangeForNumericType<Promotion>(x) ||
+                                !IsValueInRangeForNumericType<Promotion>(y)) &&
+                               x && y)) {
+      return false;
+    }
+
+    Promotion presult = {};
+    bool is_valid = true;
+    if (CheckedMulFastOp<Promotion, Promotion>::is_supported) {
+      // The fast op may be available with the promoted type.
+      // The casts here are safe because of the "value in range" conditional
+      // above.
+      is_valid = CheckedMulFastOp<Promotion, Promotion>::Do(
+          static_cast<Promotion>(x), static_cast<Promotion>(y), &presult);
+    } else if (IsIntegerArithmeticSafe<Promotion, T, U>::value) {
+      presult = static_cast<Promotion>(x) * static_cast<Promotion>(y);
+    } else {
+      is_valid = CheckedMulImpl(static_cast<Promotion>(x),
+                                static_cast<Promotion>(y), &presult);
+    }
+    if (!is_valid || !IsValueInRangeForNumericType<V>(presult))
+      return false;
+    *result = static_cast<V>(presult);
+    return true;
+  }
+};
+
+// Division just requires a check for a zero denominator or an invalid negation
+// on signed min/-1.
+template <typename T, typename U>
+struct CheckedDivOp {};
+
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct CheckedDivOp<T, U> {
+  using result_type = typename MaxExponentPromotion<T, U>::type;
+  template <typename V>
+  static constexpr bool Do(T x, U y, V* result) {
+    if (BASE_NUMERICS_UNLIKELY(!y))
+      return false;
+
+    // The overflow check can be compiled away if we don't have the exact
+    // combination of types needed to trigger this case.
+    using Promotion = typename BigEnoughPromotion<T, U>::type;
+    if (BASE_NUMERICS_UNLIKELY(
+            (std::is_signed_v<T> && std::is_signed_v<U> &&
+             IsTypeInRangeForNumericType<T, Promotion>::value &&
+             static_cast<Promotion>(x) ==
+                 std::numeric_limits<Promotion>::lowest() &&
+             y == static_cast<U>(-1)))) {
+      return false;
+    }
+
+    // This branch always compiles away if the above branch wasn't removed.
+    if (BASE_NUMERICS_UNLIKELY((!IsValueInRangeForNumericType<Promotion>(x) ||
+                                !IsValueInRangeForNumericType<Promotion>(y)) &&
+                               x)) {
+      return false;
+    }
+
+    const Promotion presult = Promotion(x) / Promotion(y);
+    if (!IsValueInRangeForNumericType<V>(presult))
+      return false;
+    *result = static_cast<V>(presult);
+    return true;
+  }
+};
+
+template <typename T, typename U>
+struct CheckedModOp {};
+
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct CheckedModOp<T, U> {
+  using result_type = typename MaxExponentPromotion<T, U>::type;
+  template <typename V>
+  static constexpr bool Do(T x, U y, V* result) {
+    if (BASE_NUMERICS_UNLIKELY(!y))
+      return false;
+
+    using Promotion = typename BigEnoughPromotion<T, U>::type;
+    if (BASE_NUMERICS_UNLIKELY(
+            (std::is_signed_v<T> && std::is_signed_v<U> &&
+             IsTypeInRangeForNumericType<T, Promotion>::value &&
+             static_cast<Promotion>(x) ==
+                 std::numeric_limits<Promotion>::lowest() &&
+             y == static_cast<U>(-1)))) {
+      *result = 0;
+      return true;
+    }
+
+    const Promotion presult =
+        static_cast<Promotion>(x) % static_cast<Promotion>(y);
+    if (!IsValueInRangeForNumericType<V>(presult))
+      return false;
+    *result = static_cast<Promotion>(presult);
+    return true;
+  }
+};
+
+template <typename T, typename U>
+struct CheckedLshOp {};
+
+// Left shift. Shifts less than 0 or greater than or equal to the number
+// of bits in the promoted type are undefined. Shifts of negative values
+// are undefined. Otherwise it is defined when the result fits.
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct CheckedLshOp<T, U> {
+  using result_type = T;
+  template <typename V>
+  static constexpr bool Do(T x, U shift, V* result) {
+    // Disallow negative numbers and verify the shift is in bounds.
+    if (BASE_NUMERICS_LIKELY(!IsValueNegative(x) &&
+                             as_unsigned(shift) <
+                                 as_unsigned(std::numeric_limits<T>::digits))) {
+      // Shift as unsigned to avoid undefined behavior.
+      *result = static_cast<V>(as_unsigned(x) << shift);
+      // If the shift can be reversed, we know it was valid.
+      return *result >> shift == x;
+    }
+
+    // Handle the legal corner-case of a full-width signed shift of zero.
+    if (!std::is_signed_v<T> || x ||
+        as_unsigned(shift) != as_unsigned(std::numeric_limits<T>::digits)) {
+      return false;
+    }
+    *result = 0;
+    return true;
+  }
+};
+
+template <typename T, typename U>
+struct CheckedRshOp {};
+
+// Right shift. Shifts less than 0 or greater than or equal to the number
+// of bits in the promoted type are undefined. Otherwise, it is always defined,
+// but a right shift of a negative value is implementation-dependent.
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct CheckedRshOp<T, U> {
+  using result_type = T;
+  template <typename V>
+  static constexpr bool Do(T x, U shift, V* result) {
+    // Use sign conversion to push negative values out of range.
+    if (BASE_NUMERICS_UNLIKELY(as_unsigned(shift) >=
+                               IntegerBitsPlusSign<T>::value)) {
+      return false;
+    }
+
+    const T tmp = x >> shift;
+    if (!IsValueInRangeForNumericType<V>(tmp))
+      return false;
+    *result = static_cast<V>(tmp);
+    return true;
+  }
+};
+
+template <typename T, typename U>
+struct CheckedAndOp {};
+
+// For simplicity we support only unsigned integer results.
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct CheckedAndOp<T, U> {
+  using result_type = typename std::make_unsigned<
+      typename MaxExponentPromotion<T, U>::type>::type;
+  template <typename V>
+  static constexpr bool Do(T x, U y, V* result) {
+    const result_type tmp =
+        static_cast<result_type>(x) & static_cast<result_type>(y);
+    if (!IsValueInRangeForNumericType<V>(tmp))
+      return false;
+    *result = static_cast<V>(tmp);
+    return true;
+  }
+};
+
+template <typename T, typename U>
+struct CheckedOrOp {};
+
+// For simplicity we support only unsigned integers.
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct CheckedOrOp<T, U> {
+  using result_type = typename std::make_unsigned<
+      typename MaxExponentPromotion<T, U>::type>::type;
+  template <typename V>
+  static constexpr bool Do(T x, U y, V* result) {
+    const result_type tmp =
+        static_cast<result_type>(x) | static_cast<result_type>(y);
+    if (!IsValueInRangeForNumericType<V>(tmp))
+      return false;
+    *result = static_cast<V>(tmp);
+    return true;
+  }
+};
+
+template <typename T, typename U>
+struct CheckedXorOp {};
+
+// For simplicity we support only unsigned integers.
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct CheckedXorOp<T, U> {
+  using result_type = typename std::make_unsigned<
+      typename MaxExponentPromotion<T, U>::type>::type;
+  template <typename V>
+  static constexpr bool Do(T x, U y, V* result) {
+    const result_type tmp =
+        static_cast<result_type>(x) ^ static_cast<result_type>(y);
+    if (!IsValueInRangeForNumericType<V>(tmp))
+      return false;
+    *result = static_cast<V>(tmp);
+    return true;
+  }
+};
+
+// Max doesn't really need to be implemented this way because it can't fail,
+// but it makes the code much cleaner to use the MathOp wrappers.
+template <typename T, typename U>
+struct CheckedMaxOp {};
+
+template <typename T, typename U>
+  requires(std::is_arithmetic_v<T> && std::is_arithmetic_v<U>)
+struct CheckedMaxOp<T, U> {
+  using result_type = typename MaxExponentPromotion<T, U>::type;
+  template <typename V>
+  static constexpr bool Do(T x, U y, V* result) {
+    const result_type tmp = IsGreater<T, U>::Test(x, y)
+                                ? static_cast<result_type>(x)
+                                : static_cast<result_type>(y);
+    if (!IsValueInRangeForNumericType<V>(tmp))
+      return false;
+    *result = static_cast<V>(tmp);
+    return true;
+  }
+};
+
+// Min doesn't really need to be implemented this way because it can't fail,
+// but it makes the code much cleaner to use the MathOp wrappers.
+template <typename T, typename U>
+struct CheckedMinOp {};
+
+template <typename T, typename U>
+  requires(std::is_arithmetic_v<T> && std::is_arithmetic_v<U>)
+struct CheckedMinOp<T, U> {
+  using result_type = typename LowestValuePromotion<T, U>::type;
+  template <typename V>
+  static constexpr bool Do(T x, U y, V* result) {
+    const result_type tmp = IsLess<T, U>::Test(x, y)
+                                ? static_cast<result_type>(x)
+                                : static_cast<result_type>(y);
+    if (!IsValueInRangeForNumericType<V>(tmp))
+      return false;
+    *result = static_cast<V>(tmp);
+    return true;
+  }
+};
+
+// This is just boilerplate that wraps the standard floating point arithmetic.
+// A macro isn't the nicest solution, but it beats rewriting these repeatedly.
+#define BASE_FLOAT_ARITHMETIC_OPS(NAME, OP)                              \
+  template <typename T, typename U>                                      \
+    requires(std::is_floating_point_v<T> || std::is_floating_point_v<U>) \
+  struct Checked##NAME##Op<T, U> {                                       \
+    using result_type = typename MaxExponentPromotion<T, U>::type;       \
+    template <typename V>                                                \
+    static constexpr bool Do(T x, U y, V* result) {                      \
+      using Promotion = typename MaxExponentPromotion<T, U>::type;       \
+      const Promotion presult = x OP y;                                  \
+      if (!IsValueInRangeForNumericType<V>(presult))                     \
+        return false;                                                    \
+      *result = static_cast<V>(presult);                                 \
+      return true;                                                       \
+    }                                                                    \
+  };
+
+BASE_FLOAT_ARITHMETIC_OPS(Add, +)
+BASE_FLOAT_ARITHMETIC_OPS(Sub, -)
+BASE_FLOAT_ARITHMETIC_OPS(Mul, *)
+BASE_FLOAT_ARITHMETIC_OPS(Div, /)
+
+#undef BASE_FLOAT_ARITHMETIC_OPS
+
+// Floats carry around their validity state with them, but integers do not. So,
+// we wrap the underlying value in a specialization in order to hide that detail
+// and expose an interface via accessors.
+enum NumericRepresentation {
+  NUMERIC_INTEGER,
+  NUMERIC_FLOATING,
+  NUMERIC_UNKNOWN
+};
+
+template <typename NumericType>
+struct GetNumericRepresentation {
+  static const NumericRepresentation value =
+      std::is_integral_v<NumericType>
+          ? NUMERIC_INTEGER
+          : (std::is_floating_point_v<NumericType> ? NUMERIC_FLOATING
+                                                   : NUMERIC_UNKNOWN);
+};
+
+template <typename T,
+          NumericRepresentation type = GetNumericRepresentation<T>::value>
+class CheckedNumericState {};
+
+// Integrals require quite a bit of additional housekeeping to manage state.
+template <typename T>
+class CheckedNumericState<T, NUMERIC_INTEGER> {
+ public:
+  template <typename Src = int>
+  constexpr explicit CheckedNumericState(Src value = 0, bool is_valid = true)
+      : is_valid_(is_valid && IsValueInRangeForNumericType<T>(value)),
+        value_(WellDefinedConversionOrZero(value, is_valid_)) {
+    static_assert(std::is_arithmetic_v<Src>, "Argument must be numeric.");
+  }
+
+  template <typename Src>
+  constexpr CheckedNumericState(const CheckedNumericState<Src>& rhs)
+      : CheckedNumericState(rhs.value(), rhs.is_valid()) {}
+
+  constexpr bool is_valid() const { return is_valid_; }
+
+  constexpr T value() const { return value_; }
+
+ private:
+  // Ensures that a type conversion does not trigger undefined behavior.
+  template <typename Src>
+  static constexpr T WellDefinedConversionOrZero(Src value, bool is_valid) {
+    using SrcType = typename internal::UnderlyingType<Src>::type;
+    return (std::is_integral_v<SrcType> || is_valid) ? static_cast<T>(value)
+                                                     : 0;
+  }
+
+  // is_valid_ precedes value_ because member initializers in the constructors
+  // are evaluated in field order, and is_valid_ must be read when initializing
+  // value_.
+  bool is_valid_;
+  T value_;
+};
+
+// Floating points maintain their own validity, but need translation wrappers.
+template <typename T>
+class CheckedNumericState<T, NUMERIC_FLOATING> {
+ public:
+  template <typename Src = double>
+  constexpr explicit CheckedNumericState(Src value = 0.0, bool is_valid = true)
+      : value_(WellDefinedConversionOrNaN(
+            value,
+            is_valid && IsValueInRangeForNumericType<T>(value))) {}
+
+  template <typename Src>
+  constexpr CheckedNumericState(const CheckedNumericState<Src>& rhs)
+      : CheckedNumericState(rhs.value(), rhs.is_valid()) {}
+
+  constexpr bool is_valid() const {
+    // Written this way because std::isfinite is not reliably constexpr.
+    return IsConstantEvaluated()
+               ? value_ <= std::numeric_limits<T>::max() &&
+                     value_ >= std::numeric_limits<T>::lowest()
+               : std::isfinite(value_);
+  }
+
+  constexpr T value() const { return value_; }
+
+ private:
+  // Ensures that a type conversion does not trigger undefined behavior.
+  template <typename Src>
+  static constexpr T WellDefinedConversionOrNaN(Src value, bool is_valid) {
+    using SrcType = typename internal::UnderlyingType<Src>::type;
+    return (StaticDstRangeRelationToSrcRange<T, SrcType>::value ==
+                NUMERIC_RANGE_CONTAINED ||
+            is_valid)
+               ? static_cast<T>(value)
+               : std::numeric_limits<T>::quiet_NaN();
+  }
+
+  T value_;
+};
+
+}  // namespace internal
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_CHECKED_MATH_IMPL_H_

--- a/internal/base/numerics/clamped_math.h
+++ b/internal/base/numerics/clamped_math.h
@@ -1,0 +1,259 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_CLAMPED_MATH_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_CLAMPED_MATH_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include <type_traits>
+
+#include "internal/base/numerics/clamped_math_impl.h"  // IWYU pragma: export
+#include "internal/base/numerics/safe_conversions.h"
+#include "internal/base/numerics/safe_math_shared_impl.h"  // IWYU pragma: export
+
+namespace base {
+namespace internal {
+
+template <typename T>
+class ClampedNumeric {
+  static_assert(std::is_arithmetic_v<T>,
+                "ClampedNumeric<T>: T must be a numeric type.");
+
+ public:
+  using type = T;
+
+  constexpr ClampedNumeric() : value_(0) {}
+
+  // Copy constructor.
+  template <typename Src>
+  constexpr ClampedNumeric(const ClampedNumeric<Src>& rhs)
+      : value_(saturated_cast<T>(rhs.value_)) {}
+
+  template <typename Src>
+  friend class ClampedNumeric;
+
+  // Strictly speaking, this is not necessary, but declaring this allows class
+  // template argument deduction to be used so that it is possible to simply
+  // write `ClampedNumeric(777)` instead of `ClampedNumeric<int>(777)`.
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr ClampedNumeric(T value) : value_(value) {}
+
+  // This is not an explicit constructor because we implicitly upgrade regular
+  // numerics to ClampedNumerics to make them easier to use.
+  template <typename Src>
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr ClampedNumeric(Src value) : value_(saturated_cast<T>(value)) {
+    static_assert(UnderlyingType<Src>::is_numeric, "Argument must be numeric.");
+  }
+
+  // This is not an explicit constructor because we want a seamless conversion
+  // from StrictNumeric types.
+  template <typename Src>
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr ClampedNumeric(StrictNumeric<Src> value)
+      : value_(saturated_cast<T>(static_cast<Src>(value))) {}
+
+  // Returns a ClampedNumeric of the specified type, cast from the current
+  // ClampedNumeric, and saturated to the destination type.
+  template <typename Dst>
+  constexpr ClampedNumeric<typename UnderlyingType<Dst>::type> Cast() const {
+    return *this;
+  }
+
+  // Prototypes for the supported arithmetic operator overloads.
+  template <typename Src>
+  constexpr ClampedNumeric& operator+=(const Src rhs);
+  template <typename Src>
+  constexpr ClampedNumeric& operator-=(const Src rhs);
+  template <typename Src>
+  constexpr ClampedNumeric& operator*=(const Src rhs);
+  template <typename Src>
+  constexpr ClampedNumeric& operator/=(const Src rhs);
+  template <typename Src>
+  constexpr ClampedNumeric& operator%=(const Src rhs);
+  template <typename Src>
+  constexpr ClampedNumeric& operator<<=(const Src rhs);
+  template <typename Src>
+  constexpr ClampedNumeric& operator>>=(const Src rhs);
+  template <typename Src>
+  constexpr ClampedNumeric& operator&=(const Src rhs);
+  template <typename Src>
+  constexpr ClampedNumeric& operator|=(const Src rhs);
+  template <typename Src>
+  constexpr ClampedNumeric& operator^=(const Src rhs);
+
+  constexpr ClampedNumeric operator-() const {
+    // The negation of two's complement int min is int min, so that's the
+    // only overflow case where we will saturate.
+    return ClampedNumeric<T>(SaturatedNegWrapper(value_));
+  }
+
+  constexpr ClampedNumeric operator~() const {
+    return ClampedNumeric<decltype(InvertWrapper(T()))>(InvertWrapper(value_));
+  }
+
+  constexpr ClampedNumeric Abs() const {
+    // The negation of two's complement int min is int min, so that's the
+    // only overflow case where we will saturate.
+    return ClampedNumeric<T>(SaturatedAbsWrapper(value_));
+  }
+
+  template <typename U>
+  constexpr ClampedNumeric<typename MathWrapper<ClampedMaxOp, T, U>::type> Max(
+      const U rhs) const {
+    using result_type = typename MathWrapper<ClampedMaxOp, T, U>::type;
+    return ClampedNumeric<result_type>(
+        ClampedMaxOp<T, U>::Do(value_, Wrapper<U>::value(rhs)));
+  }
+
+  template <typename U>
+  constexpr ClampedNumeric<typename MathWrapper<ClampedMinOp, T, U>::type> Min(
+      const U rhs) const {
+    using result_type = typename MathWrapper<ClampedMinOp, T, U>::type;
+    return ClampedNumeric<result_type>(
+        ClampedMinOp<T, U>::Do(value_, Wrapper<U>::value(rhs)));
+  }
+
+  // This function is available only for integral types. It returns an unsigned
+  // integer of the same width as the source type, containing the absolute value
+  // of the source, and properly handling signed min.
+  constexpr ClampedNumeric<typename UnsignedOrFloatForSize<T>::type>
+  UnsignedAbs() const {
+    return ClampedNumeric<typename UnsignedOrFloatForSize<T>::type>(
+        SafeUnsignedAbs(value_));
+  }
+
+  constexpr ClampedNumeric& operator++() {
+    *this += 1;
+    return *this;
+  }
+
+  constexpr ClampedNumeric operator++(int) {
+    ClampedNumeric value = *this;
+    *this += 1;
+    return value;
+  }
+
+  constexpr ClampedNumeric& operator--() {
+    *this -= 1;
+    return *this;
+  }
+
+  constexpr ClampedNumeric operator--(int) {
+    ClampedNumeric value = *this;
+    *this -= 1;
+    return value;
+  }
+
+  // These perform the actual math operations on the ClampedNumerics.
+  // Binary arithmetic operations.
+  template <template <typename, typename> class M, typename L, typename R>
+  static constexpr ClampedNumeric MathOp(const L lhs, const R rhs) {
+    using Math = typename MathWrapper<M, L, R>::math;
+    return ClampedNumeric<T>(
+        Math::template Do<T>(Wrapper<L>::value(lhs), Wrapper<R>::value(rhs)));
+  }
+
+  // Assignment arithmetic operations.
+  template <template <typename, typename> class M, typename R>
+  constexpr ClampedNumeric& MathOp(const R rhs) {
+    using Math = typename MathWrapper<M, T, R>::math;
+    *this =
+        ClampedNumeric<T>(Math::template Do<T>(value_, Wrapper<R>::value(rhs)));
+    return *this;
+  }
+
+  template <typename Dst>
+  constexpr operator Dst() const {
+    return saturated_cast<typename ArithmeticOrUnderlyingEnum<Dst>::type>(
+        value_);
+  }
+
+  // This method extracts the raw integer value without saturating it to the
+  // destination type as the conversion operator does. This is useful when
+  // e.g. assigning to an auto type or passing as a deduced template parameter.
+  constexpr T RawValue() const { return value_; }
+
+ private:
+  T value_;
+
+  // These wrappers allow us to handle state the same way for both
+  // ClampedNumeric and POD arithmetic types.
+  template <typename Src>
+  struct Wrapper {
+    static constexpr typename UnderlyingType<Src>::type value(Src value) {
+      return value;
+    }
+  };
+};
+
+// Convenience wrapper to return a new ClampedNumeric from the provided
+// arithmetic or ClampedNumericType.
+template <typename T>
+constexpr ClampedNumeric<typename UnderlyingType<T>::type> MakeClampedNum(
+    const T value) {
+  return value;
+}
+
+// These implement the variadic wrapper for the math operations.
+template <template <typename, typename> class M, typename L, typename R>
+constexpr ClampedNumeric<typename MathWrapper<M, L, R>::type> ClampMathOp(
+    const L lhs,
+    const R rhs) {
+  using Math = typename MathWrapper<M, L, R>::math;
+  return ClampedNumeric<typename Math::result_type>::template MathOp<M>(lhs,
+                                                                        rhs);
+}
+
+// General purpose wrapper template for arithmetic operations.
+template <template <typename, typename> class M,
+          typename L,
+          typename R,
+          typename... Args>
+constexpr auto ClampMathOp(const L lhs, const R rhs, const Args... args) {
+  return ClampMathOp<M>(ClampMathOp<M>(lhs, rhs), args...);
+}
+
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Clamped, Clamp, Add, +, +=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Clamped, Clamp, Sub, -, -=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Clamped, Clamp, Mul, *, *=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Clamped, Clamp, Div, /, /=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Clamped, Clamp, Mod, %, %=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Clamped, Clamp, Lsh, <<, <<=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Clamped, Clamp, Rsh, >>, >>=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Clamped, Clamp, And, &, &=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Clamped, Clamp, Or, |, |=)
+BASE_NUMERIC_ARITHMETIC_OPERATORS(Clamped, Clamp, Xor, ^, ^=)
+BASE_NUMERIC_ARITHMETIC_VARIADIC(Clamped, Clamp, Max)
+BASE_NUMERIC_ARITHMETIC_VARIADIC(Clamped, Clamp, Min)
+BASE_NUMERIC_COMPARISON_OPERATORS(Clamped, IsLess, <)
+BASE_NUMERIC_COMPARISON_OPERATORS(Clamped, IsLessOrEqual, <=)
+BASE_NUMERIC_COMPARISON_OPERATORS(Clamped, IsGreater, >)
+BASE_NUMERIC_COMPARISON_OPERATORS(Clamped, IsGreaterOrEqual, >=)
+BASE_NUMERIC_COMPARISON_OPERATORS(Clamped, IsEqual, ==)
+BASE_NUMERIC_COMPARISON_OPERATORS(Clamped, IsNotEqual, !=)
+
+}  // namespace internal
+
+using internal::ClampAdd;
+using internal::ClampAnd;
+using internal::ClampDiv;
+using internal::ClampedNumeric;
+using internal::ClampLsh;
+using internal::ClampMax;
+using internal::ClampMin;
+using internal::ClampMod;
+using internal::ClampMul;
+using internal::ClampOr;
+using internal::ClampRsh;
+using internal::ClampSub;
+using internal::ClampXor;
+using internal::MakeClampedNum;
+
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_CLAMPED_MATH_H_

--- a/internal/base/numerics/clamped_math_impl.h
+++ b/internal/base/numerics/clamped_math_impl.h
@@ -1,0 +1,309 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_CLAMPED_MATH_IMPL_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_CLAMPED_MATH_IMPL_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+// IWYU pragma: private, include "base/numerics/clamped_math.h"
+
+#include <concepts>
+#include <limits>
+#include <type_traits>
+
+#include "internal/base/numerics/checked_math.h"
+#include "internal/base/numerics/safe_conversions.h"
+#include "internal/base/numerics/safe_math_shared_impl.h"  // IWYU pragma: export
+
+namespace base {
+namespace internal {
+
+template <typename T>
+  requires(std::signed_integral<T>)
+constexpr T SaturatedNegWrapper(T value) {
+  return IsConstantEvaluated() || !ClampedNegFastOp<T>::is_supported
+             ? (NegateWrapper(value) != std::numeric_limits<T>::lowest()
+                    ? NegateWrapper(value)
+                    : std::numeric_limits<T>::max())
+             : ClampedNegFastOp<T>::Do(value);
+}
+
+template <typename T>
+  requires(std::unsigned_integral<T>)
+constexpr T SaturatedNegWrapper(T value) {
+  return T(0);
+}
+
+template <typename T>
+  requires(std::floating_point<T>)
+constexpr T SaturatedNegWrapper(T value) {
+  return -value;
+}
+
+template <typename T>
+  requires(std::integral<T>)
+constexpr T SaturatedAbsWrapper(T value) {
+  // The calculation below is a static identity for unsigned types, but for
+  // signed integer types it provides a non-branching, saturated absolute value.
+  // This works because SafeUnsignedAbs() returns an unsigned type, which can
+  // represent the absolute value of all negative numbers of an equal-width
+  // integer type. The call to IsValueNegative() then detects overflow in the
+  // special case of numeric_limits<T>::min(), by evaluating the bit pattern as
+  // a signed integer value. If it is the overflow case, we end up subtracting
+  // one from the unsigned result, thus saturating to numeric_limits<T>::max().
+  return static_cast<T>(
+      SafeUnsignedAbs(value) -
+      IsValueNegative<T>(static_cast<T>(SafeUnsignedAbs(value))));
+}
+
+template <typename T>
+  requires(std::floating_point<T>)
+constexpr T SaturatedAbsWrapper(T value) {
+  return value < 0 ? -value : value;
+}
+
+template <typename T, typename U>
+struct ClampedAddOp {};
+
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct ClampedAddOp<T, U> {
+  using result_type = typename MaxExponentPromotion<T, U>::type;
+  template <typename V = result_type>
+  static constexpr V Do(T x, U y) {
+    if (!IsConstantEvaluated() && ClampedAddFastOp<T, U>::is_supported)
+      return ClampedAddFastOp<T, U>::template Do<V>(x, y);
+
+    static_assert(std::is_same_v<V, result_type> ||
+                      IsTypeInRangeForNumericType<U, V>::value,
+                  "The saturation result cannot be determined from the "
+                  "provided types.");
+    const V saturated = CommonMaxOrMin<V>(IsValueNegative(y));
+    V result = {};
+    return BASE_NUMERICS_LIKELY((CheckedAddOp<T, U>::Do(x, y, &result)))
+               ? result
+               : saturated;
+  }
+};
+
+template <typename T, typename U>
+struct ClampedSubOp {};
+
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct ClampedSubOp<T, U> {
+  using result_type = typename MaxExponentPromotion<T, U>::type;
+  template <typename V = result_type>
+  static constexpr V Do(T x, U y) {
+    if (!IsConstantEvaluated() && ClampedSubFastOp<T, U>::is_supported)
+      return ClampedSubFastOp<T, U>::template Do<V>(x, y);
+
+    static_assert(std::is_same_v<V, result_type> ||
+                      IsTypeInRangeForNumericType<U, V>::value,
+                  "The saturation result cannot be determined from the "
+                  "provided types.");
+    const V saturated = CommonMaxOrMin<V>(!IsValueNegative(y));
+    V result = {};
+    return BASE_NUMERICS_LIKELY((CheckedSubOp<T, U>::Do(x, y, &result)))
+               ? result
+               : saturated;
+  }
+};
+
+template <typename T, typename U>
+struct ClampedMulOp {};
+
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct ClampedMulOp<T, U> {
+  using result_type = typename MaxExponentPromotion<T, U>::type;
+  template <typename V = result_type>
+  static constexpr V Do(T x, U y) {
+    if (!IsConstantEvaluated() && ClampedMulFastOp<T, U>::is_supported)
+      return ClampedMulFastOp<T, U>::template Do<V>(x, y);
+
+    V result = {};
+    const V saturated =
+        CommonMaxOrMin<V>(IsValueNegative(x) ^ IsValueNegative(y));
+    return BASE_NUMERICS_LIKELY((CheckedMulOp<T, U>::Do(x, y, &result)))
+               ? result
+               : saturated;
+  }
+};
+
+template <typename T, typename U>
+struct ClampedDivOp {};
+
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct ClampedDivOp<T, U> {
+  using result_type = typename MaxExponentPromotion<T, U>::type;
+  template <typename V = result_type>
+  static constexpr V Do(T x, U y) {
+    V result = {};
+    if (BASE_NUMERICS_LIKELY((CheckedDivOp<T, U>::Do(x, y, &result))))
+      return result;
+    // Saturation goes to max, min, or NaN (if x is zero).
+    return x ? CommonMaxOrMin<V>(IsValueNegative(x) ^ IsValueNegative(y))
+             : SaturationDefaultLimits<V>::NaN();
+  }
+};
+
+template <typename T, typename U>
+struct ClampedModOp {};
+
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct ClampedModOp<T, U> {
+  using result_type = typename MaxExponentPromotion<T, U>::type;
+  template <typename V = result_type>
+  static constexpr V Do(T x, U y) {
+    V result = {};
+    return BASE_NUMERICS_LIKELY((CheckedModOp<T, U>::Do(x, y, &result)))
+               ? result
+               : x;
+  }
+};
+
+template <typename T, typename U>
+struct ClampedLshOp {};
+
+// Left shift. Non-zero values saturate in the direction of the sign. A zero
+// shifted by any value always results in zero.
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct ClampedLshOp<T, U> {
+  using result_type = T;
+  template <typename V = result_type>
+  static constexpr V Do(T x, U shift) {
+    static_assert(!std::is_signed_v<U>, "Shift value must be unsigned.");
+    if (BASE_NUMERICS_LIKELY(shift < std::numeric_limits<T>::digits)) {
+      // Shift as unsigned to avoid undefined behavior.
+      V result = static_cast<V>(as_unsigned(x) << shift);
+      // If the shift can be reversed, we know it was valid.
+      if (BASE_NUMERICS_LIKELY(result >> shift == x))
+        return result;
+    }
+    return x ? CommonMaxOrMin<V>(IsValueNegative(x)) : 0;
+  }
+};
+
+template <typename T, typename U>
+struct ClampedRshOp {};
+
+// Right shift. Negative values saturate to -1. Positive or 0 saturates to 0.
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct ClampedRshOp<T, U> {
+  using result_type = T;
+  template <typename V = result_type>
+  static constexpr V Do(T x, U shift) {
+    static_assert(!std::is_signed_v<U>, "Shift value must be unsigned.");
+    // Signed right shift is odd, because it saturates to -1 or 0.
+    const V saturated = as_unsigned(V(0)) - IsValueNegative(x);
+    return BASE_NUMERICS_LIKELY(shift < IntegerBitsPlusSign<T>::value)
+               ? saturated_cast<V>(x >> shift)
+               : saturated;
+  }
+};
+
+template <typename T, typename U>
+struct ClampedAndOp {};
+
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct ClampedAndOp<T, U> {
+  using result_type = typename std::make_unsigned<
+      typename MaxExponentPromotion<T, U>::type>::type;
+  template <typename V>
+  static constexpr V Do(T x, U y) {
+    return static_cast<result_type>(x) & static_cast<result_type>(y);
+  }
+};
+
+template <typename T, typename U>
+struct ClampedOrOp {};
+
+// For simplicity we promote to unsigned integers.
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct ClampedOrOp<T, U> {
+  using result_type = typename std::make_unsigned<
+      typename MaxExponentPromotion<T, U>::type>::type;
+  template <typename V>
+  static constexpr V Do(T x, U y) {
+    return static_cast<result_type>(x) | static_cast<result_type>(y);
+  }
+};
+
+template <typename T, typename U>
+struct ClampedXorOp {};
+
+// For simplicity we support only unsigned integers.
+template <typename T, typename U>
+  requires(std::integral<T> && std::integral<U>)
+struct ClampedXorOp<T, U> {
+  using result_type = typename std::make_unsigned<
+      typename MaxExponentPromotion<T, U>::type>::type;
+  template <typename V>
+  static constexpr V Do(T x, U y) {
+    return static_cast<result_type>(x) ^ static_cast<result_type>(y);
+  }
+};
+
+template <typename T, typename U>
+struct ClampedMaxOp {};
+
+template <typename T, typename U>
+  requires(std::is_arithmetic_v<T> && std::is_arithmetic_v<U>)
+struct ClampedMaxOp<T, U> {
+  using result_type = typename MaxExponentPromotion<T, U>::type;
+  template <typename V = result_type>
+  static constexpr V Do(T x, U y) {
+    return IsGreater<T, U>::Test(x, y) ? saturated_cast<V>(x)
+                                       : saturated_cast<V>(y);
+  }
+};
+
+template <typename T, typename U>
+struct ClampedMinOp {};
+
+template <typename T, typename U>
+  requires(std::is_arithmetic_v<T> && std::is_arithmetic_v<U>)
+struct ClampedMinOp<T, U> {
+  using result_type = typename LowestValuePromotion<T, U>::type;
+  template <typename V = result_type>
+  static constexpr V Do(T x, U y) {
+    return IsLess<T, U>::Test(x, y) ? saturated_cast<V>(x)
+                                    : saturated_cast<V>(y);
+  }
+};
+
+// This is just boilerplate that wraps the standard floating point arithmetic.
+// A macro isn't the nicest solution, but it beats rewriting these repeatedly.
+#define BASE_FLOAT_ARITHMETIC_OPS(NAME, OP)                        \
+  template <typename T, typename U>                                \
+    requires(std::floating_point<T> || std::floating_point<U>)     \
+  struct Clamped##NAME##Op<T, U> {                                 \
+    using result_type = typename MaxExponentPromotion<T, U>::type; \
+    template <typename V = result_type>                            \
+    static constexpr V Do(T x, U y) {                              \
+      return saturated_cast<V>(x OP y);                            \
+    }                                                              \
+  };
+
+BASE_FLOAT_ARITHMETIC_OPS(Add, +)
+BASE_FLOAT_ARITHMETIC_OPS(Sub, -)
+BASE_FLOAT_ARITHMETIC_OPS(Mul, *)
+BASE_FLOAT_ARITHMETIC_OPS(Div, /)
+
+#undef BASE_FLOAT_ARITHMETIC_OPS
+
+}  // namespace internal
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_CLAMPED_MATH_IMPL_H_

--- a/internal/base/numerics/math_constants.h
+++ b/internal/base/numerics/math_constants.h
@@ -1,0 +1,19 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_MATH_CONSTANTS_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_MATH_CONSTANTS_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+namespace base {
+// The mean acceleration due to gravity on Earth in m/s^2.
+constexpr double kMeanGravityDouble = 9.80665;
+constexpr float kMeanGravityFloat = 9.80665f;
+
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_MATH_CONSTANTS_H_

--- a/internal/base/numerics/ostream_operators.h
+++ b/internal/base/numerics/ostream_operators.h
@@ -1,0 +1,39 @@
+// Copyright 2021 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_OSTREAM_OPERATORS_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_OSTREAM_OPERATORS_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include <ostream>
+
+namespace base {
+namespace internal {
+
+template <typename T>
+class ClampedNumeric;
+template <typename T>
+class StrictNumeric;
+
+// Overload the ostream output operator to make logging work nicely.
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const StrictNumeric<T>& value) {
+  os << static_cast<T>(value);
+  return os;
+}
+
+// Overload the ostream output operator to make logging work nicely.
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const ClampedNumeric<T>& value) {
+  os << static_cast<T>(value);
+  return os;
+}
+
+}  // namespace internal
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_OSTREAM_OPERATORS_H_

--- a/internal/base/numerics/ranges.h
+++ b/internal/base/numerics/ranges.h
@@ -1,0 +1,25 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_RANGES_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_RANGES_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include <cmath>
+#include <type_traits>
+
+namespace base {
+
+template <typename T>
+constexpr bool IsApproximatelyEqual(T lhs, T rhs, T tolerance) {
+  static_assert(std::is_arithmetic_v<T>, "Argument must be arithmetic");
+  return std::abs(rhs - lhs) <= tolerance;
+}
+
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_RANGES_H_

--- a/internal/base/numerics/safe_conversions.h
+++ b/internal/base/numerics/safe_conversions.h
@@ -1,0 +1,390 @@
+// Copyright 2014 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_CONVERSIONS_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_CONVERSIONS_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include <stddef.h>
+
+#include <cmath>
+#include <concepts>
+#include <limits>
+#include <type_traits>
+
+#include "internal/base/numerics/safe_conversions_impl.h"  // IWYU pragma: export
+
+#if defined(__ARMEL__) && !defined(__native_client__)
+#include "base/numerics/safe_conversions_arm_impl.h"  // IWYU pragma: export
+#define BASE_HAS_OPTIMIZED_SAFE_CONVERSIONS (1)
+#else
+#define BASE_HAS_OPTIMIZED_SAFE_CONVERSIONS (0)
+#endif
+
+namespace base {
+namespace internal {
+
+#if !BASE_HAS_OPTIMIZED_SAFE_CONVERSIONS
+template <typename Dst, typename Src>
+struct SaturateFastAsmOp {
+  static constexpr bool is_supported = false;
+  static constexpr Dst Do(Src) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<Dst>();
+  }
+};
+#endif  // BASE_HAS_OPTIMIZED_SAFE_CONVERSIONS
+#undef BASE_HAS_OPTIMIZED_SAFE_CONVERSIONS
+
+// The following special case a few specific integer conversions where we can
+// eke out better performance than range checking.
+template <typename Dst, typename Src>
+struct IsValueInRangeFastOp {
+  static constexpr bool is_supported = false;
+  static constexpr bool Do(Src value) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<bool>();
+  }
+};
+
+// Signed to signed range comparison.
+template <typename Dst, typename Src>
+  requires(std::signed_integral<Dst> && std::signed_integral<Src> &&
+           !IsTypeInRangeForNumericType<Dst, Src>::value)
+struct IsValueInRangeFastOp<Dst, Src> {
+  static constexpr bool is_supported = true;
+
+  static constexpr bool Do(Src value) {
+    // Just downcast to the smaller type, sign extend it back to the original
+    // type, and then see if it matches the original value.
+    return value == static_cast<Dst>(value);
+  }
+};
+
+// Signed to unsigned range comparison.
+template <typename Dst, typename Src>
+  requires(std::unsigned_integral<Dst> && std::signed_integral<Src> &&
+           !IsTypeInRangeForNumericType<Dst, Src>::value)
+struct IsValueInRangeFastOp<Dst, Src> {
+  static constexpr bool is_supported = true;
+
+  static constexpr bool Do(Src value) {
+    // We cast a signed as unsigned to overflow negative values to the top,
+    // then compare against whichever maximum is smaller, as our upper bound.
+    return as_unsigned(value) <= as_unsigned(CommonMax<Src, Dst>());
+  }
+};
+
+// Convenience function that returns true if the supplied value is in range
+// for the destination type.
+template <typename Dst, typename Src>
+constexpr bool IsValueInRangeForNumericType(Src value) {
+  using SrcType = typename internal::UnderlyingType<Src>::type;
+  return internal::IsValueInRangeFastOp<Dst, SrcType>::is_supported
+             ? internal::IsValueInRangeFastOp<Dst, SrcType>::Do(
+                   static_cast<SrcType>(value))
+             : internal::DstRangeRelationToSrcRange<Dst>(
+                   static_cast<SrcType>(value))
+                   .IsValid();
+}
+
+// checked_cast<> is analogous to static_cast<> for numeric types,
+// except that it CHECKs that the specified numeric conversion will not
+// overflow or underflow. NaN source will always trigger a CHECK.
+template <typename Dst,
+          class CheckHandler = internal::CheckOnFailure,
+          typename Src>
+constexpr Dst checked_cast(Src value) {
+  // This throws a compile-time error on evaluating the constexpr if it can be
+  // determined at compile-time as failing, otherwise it will CHECK at runtime.
+  using SrcType = typename internal::UnderlyingType<Src>::type;
+  return BASE_NUMERICS_LIKELY((IsValueInRangeForNumericType<Dst>(value)))
+             ? static_cast<Dst>(static_cast<SrcType>(value))
+             : CheckHandler::template HandleFailure<Dst>();
+}
+
+// Default boundaries for integral/float: max/infinity, lowest/-infinity, 0/NaN.
+// You may provide your own limits (e.g. to saturated_cast) so long as you
+// implement all of the static constexpr member functions in the class below.
+template <typename T>
+struct SaturationDefaultLimits : public std::numeric_limits<T> {
+  static constexpr T NaN() {
+    if constexpr (std::numeric_limits<T>::has_quiet_NaN) {
+      return std::numeric_limits<T>::quiet_NaN();
+    } else {
+      return T();
+    }
+  }
+  using std::numeric_limits<T>::max;
+  static constexpr T Overflow() {
+    if constexpr (std::numeric_limits<T>::has_infinity) {
+      return std::numeric_limits<T>::infinity();
+    } else {
+      return std::numeric_limits<T>::max();
+    }
+  }
+  using std::numeric_limits<T>::lowest;
+  static constexpr T Underflow() {
+    if constexpr (std::numeric_limits<T>::has_infinity) {
+      return std::numeric_limits<T>::infinity() * -1;
+    } else {
+      return std::numeric_limits<T>::lowest();
+    }
+  }
+};
+
+template <typename Dst, template <typename> class S, typename Src>
+constexpr Dst saturated_cast_impl(Src value, RangeCheck constraint) {
+  // For some reason clang generates much better code when the branch is
+  // structured exactly this way, rather than a sequence of checks.
+  return !constraint.IsOverflowFlagSet()
+             ? (!constraint.IsUnderflowFlagSet() ? static_cast<Dst>(value)
+                                                 : S<Dst>::Underflow())
+             // Skip this check for integral Src, which cannot be NaN.
+             : (std::is_integral_v<Src> || !constraint.IsUnderflowFlagSet()
+                    ? S<Dst>::Overflow()
+                    : S<Dst>::NaN());
+}
+
+// We can reduce the number of conditions and get slightly better performance
+// for normal signed and unsigned integer ranges. And in the specific case of
+// Arm, we can use the optimized saturation instructions.
+template <typename Dst, typename Src>
+struct SaturateFastOp {
+  static constexpr bool is_supported = false;
+  static constexpr Dst Do(Src value) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<Dst>();
+  }
+};
+
+template <typename Dst, typename Src>
+  requires(std::integral<Src> && std::integral<Dst> &&
+           SaturateFastAsmOp<Dst, Src>::is_supported)
+struct SaturateFastOp<Dst, Src> {
+  static constexpr bool is_supported = true;
+  static constexpr Dst Do(Src value) {
+    return SaturateFastAsmOp<Dst, Src>::Do(value);
+  }
+};
+
+template <typename Dst, typename Src>
+  requires(std::integral<Src> && std::integral<Dst> &&
+           !SaturateFastAsmOp<Dst, Src>::is_supported)
+struct SaturateFastOp<Dst, Src> {
+  static constexpr bool is_supported = true;
+  static constexpr Dst Do(Src value) {
+    // The exact order of the following is structured to hit the correct
+    // optimization heuristics across compilers. Do not change without
+    // checking the emitted code.
+    const Dst saturated = CommonMaxOrMin<Dst, Src>(
+        IsMaxInRangeForNumericType<Dst, Src>() ||
+        (!IsMinInRangeForNumericType<Dst, Src>() && IsValueNegative(value)));
+    return BASE_NUMERICS_LIKELY(IsValueInRangeForNumericType<Dst>(value))
+               ? static_cast<Dst>(value)
+               : saturated;
+  }
+};
+
+// saturated_cast<> is analogous to static_cast<> for numeric types, except
+// that the specified numeric conversion will saturate by default rather than
+// overflow or underflow, and NaN assignment to an integral will return 0.
+// All boundary condition behaviors can be overridden with a custom handler.
+template <typename Dst,
+          template <typename> class SaturationHandler = SaturationDefaultLimits,
+          typename Src>
+constexpr Dst saturated_cast(Src value) {
+  using SrcType = typename UnderlyingType<Src>::type;
+  return !IsConstantEvaluated() && SaturateFastOp<Dst, SrcType>::is_supported &&
+                 std::is_same_v<SaturationHandler<Dst>,
+                                SaturationDefaultLimits<Dst>>
+             ? SaturateFastOp<Dst, SrcType>::Do(static_cast<SrcType>(value))
+             : saturated_cast_impl<Dst, SaturationHandler, SrcType>(
+                   static_cast<SrcType>(value),
+                   DstRangeRelationToSrcRange<Dst, SaturationHandler, SrcType>(
+                       static_cast<SrcType>(value)));
+}
+
+// strict_cast<> is analogous to static_cast<> for numeric types, except that
+// it will cause a compile failure if the destination type is not large enough
+// to contain any value in the source type. It performs no runtime checking.
+template <typename Dst, typename Src>
+constexpr Dst strict_cast(Src value) {
+  using SrcType = typename UnderlyingType<Src>::type;
+  static_assert(UnderlyingType<Src>::is_numeric, "Argument must be numeric.");
+  static_assert(std::is_arithmetic_v<Dst>, "Result must be numeric.");
+
+  // If you got here from a compiler error, it's because you tried to assign
+  // from a source type to a destination type that has insufficient range.
+  // The solution may be to change the destination type you're assigning to,
+  // and use one large enough to represent the source.
+  // Alternatively, you may be better served with the checked_cast<> or
+  // saturated_cast<> template functions for your particular use case.
+  static_assert(StaticDstRangeRelationToSrcRange<Dst, SrcType>::value ==
+                    NUMERIC_RANGE_CONTAINED,
+                "The source type is out of range for the destination type. "
+                "Please see strict_cast<> comments for more information.");
+
+  return static_cast<Dst>(static_cast<SrcType>(value));
+}
+
+// Some wrappers to statically check that a type is in range.
+template <typename Dst, typename Src>
+struct IsNumericRangeContained {
+  static constexpr bool value = false;
+};
+
+template <typename Dst, typename Src>
+  requires(ArithmeticOrUnderlyingEnum<Dst>::value &&
+           ArithmeticOrUnderlyingEnum<Src>::value)
+struct IsNumericRangeContained<Dst, Src> {
+  static constexpr bool value =
+      StaticDstRangeRelationToSrcRange<Dst, Src>::value ==
+      NUMERIC_RANGE_CONTAINED;
+};
+
+// StrictNumeric implements compile time range checking between numeric types by
+// wrapping assignment operations in a strict_cast. This class is intended to be
+// used for function arguments and return types, to ensure the destination type
+// can always contain the source type. This is essentially the same as enforcing
+// -Wconversion in gcc and C4302 warnings on MSVC, but it can be applied
+// incrementally at API boundaries, making it easier to convert code so that it
+// compiles cleanly with truncation warnings enabled.
+// This template should introduce no runtime overhead, but it also provides no
+// runtime checking of any of the associated mathematical operations. Use
+// CheckedNumeric for runtime range checks of the actual value being assigned.
+template <typename T>
+class StrictNumeric {
+ public:
+  using type = T;
+
+  constexpr StrictNumeric() : value_(0) {}
+
+  // Copy constructor.
+  template <typename Src>
+  constexpr StrictNumeric(const StrictNumeric<Src>& rhs)
+      : value_(strict_cast<T>(rhs.value_)) {}
+
+  // Strictly speaking, this is not necessary, but declaring this allows class
+  // template argument deduction to be used so that it is possible to simply
+  // write `StrictNumeric(777)` instead of `StrictNumeric<int>(777)`.
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr StrictNumeric(T value) : value_(value) {}
+
+  // This is not an explicit constructor because we implicitly upgrade regular
+  // numerics to StrictNumerics to make them easier to use.
+  template <typename Src>
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr StrictNumeric(Src value) : value_(strict_cast<T>(value)) {}
+
+  // If you got here from a compiler error, it's because you tried to assign
+  // from a source type to a destination type that has insufficient range.
+  // The solution may be to change the destination type you're assigning to,
+  // and use one large enough to represent the source.
+  // If you're assigning from a CheckedNumeric<> class, you may be able to use
+  // the AssignIfValid() member function, specify a narrower destination type to
+  // the member value functions (e.g. val.template ValueOrDie<Dst>()), use one
+  // of the value helper functions (e.g. ValueOrDieForType<Dst>(val)).
+  // If you've encountered an _ambiguous overload_ you can use a static_cast<>
+  // to explicitly cast the result to the destination type.
+  // If none of that works, you may be better served with the checked_cast<> or
+  // saturated_cast<> template functions for your particular use case.
+  template <typename Dst>
+    requires(IsNumericRangeContained<Dst, T>::value)
+  constexpr operator Dst() const {
+    return static_cast<typename ArithmeticOrUnderlyingEnum<Dst>::type>(value_);
+  }
+
+ private:
+  const T value_;
+};
+
+// Convenience wrapper returns a StrictNumeric from the provided arithmetic
+// type.
+template <typename T>
+constexpr StrictNumeric<typename UnderlyingType<T>::type> MakeStrictNum(
+    const T value) {
+  return value;
+}
+
+#define BASE_NUMERIC_COMPARISON_OPERATORS(CLASS, NAME, OP)          \
+  template <typename L, typename R>                                 \
+    requires(internal::Is##CLASS##Op<L, R>::value)                  \
+  constexpr bool operator OP(const L lhs, const R rhs) {            \
+    return SafeCompare<NAME, typename UnderlyingType<L>::type,      \
+                       typename UnderlyingType<R>::type>(lhs, rhs); \
+  }
+
+BASE_NUMERIC_COMPARISON_OPERATORS(Strict, IsLess, <)
+BASE_NUMERIC_COMPARISON_OPERATORS(Strict, IsLessOrEqual, <=)
+BASE_NUMERIC_COMPARISON_OPERATORS(Strict, IsGreater, >)
+BASE_NUMERIC_COMPARISON_OPERATORS(Strict, IsGreaterOrEqual, >=)
+BASE_NUMERIC_COMPARISON_OPERATORS(Strict, IsEqual, ==)
+BASE_NUMERIC_COMPARISON_OPERATORS(Strict, IsNotEqual, !=)
+
+}  // namespace internal
+
+using internal::as_signed;
+using internal::as_unsigned;
+using internal::checked_cast;
+using internal::IsTypeInRangeForNumericType;
+using internal::IsValueInRangeForNumericType;
+using internal::IsValueNegative;
+using internal::MakeStrictNum;
+using internal::SafeUnsignedAbs;
+using internal::saturated_cast;
+using internal::strict_cast;
+using internal::StrictNumeric;
+
+// Explicitly make a shorter size_t alias for convenience.
+using SizeT = StrictNumeric<size_t>;
+
+// floating -> integral conversions that saturate and thus can actually return
+// an integral type.
+//
+// Generally, what you want is saturated_cast<Dst>(std::nearbyint(x)), which
+// rounds correctly according to IEEE-754 (round to nearest, ties go to nearest
+// even number; this avoids bias). If your code is performance-critical
+// and you are sure that you will never overflow, you can use std::lrint()
+// or std::llrint(), which return a long or long long directly.
+//
+// Below are convenience functions around similar patterns, except that
+// they round in nonstandard directions and will generally be slower.
+
+// Rounds towards negative infinity (i.e., down).
+template <typename Dst = int, typename Src>
+  requires(std::integral<Dst> && std::floating_point<Src>)
+Dst ClampFloor(Src value) {
+  return saturated_cast<Dst>(std::floor(value));
+}
+
+// Rounds towards positive infinity (i.e., up).
+template <typename Dst = int, typename Src>
+  requires(std::integral<Dst> && std::floating_point<Src>)
+Dst ClampCeil(Src value) {
+  return saturated_cast<Dst>(std::ceil(value));
+}
+
+// Rounds towards nearest integer, with ties away from zero.
+// This means that 0.5 will be rounded to 1 and 1.5 will be rounded to 2.
+// Similarly, -0.5 will be rounded to -1 and -1.5 will be rounded to -2.
+//
+// This is normally not what you want accuracy-wise (it introduces a small bias
+// away from zero), and it is not the fastest option, but it is frequently what
+// existing code expects. Compare with saturated_cast<Dst>(std::nearbyint(x))
+// or std::lrint(x), which would round 0.5 and -0.5 to 0 but 1.5 to 2 and
+// -1.5 to -2.
+template <typename Dst = int, typename Src>
+  requires(std::integral<Dst> && std::floating_point<Src>)
+Dst ClampRound(Src value) {
+  const Src rounded = std::round(value);
+  return saturated_cast<Dst>(rounded);
+}
+
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_CONVERSIONS_H_

--- a/internal/base/numerics/safe_conversions_arm_impl.h
+++ b/internal/base/numerics/safe_conversions_arm_impl.h
@@ -1,0 +1,56 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_CONVERSIONS_ARM_IMPL_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_CONVERSIONS_ARM_IMPL_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+// IWYU pragma: private, include "base/numerics/safe_conversions.h"
+
+#include <stdint.h>
+#include <type_traits>
+
+#include "internal/base/numerics/safe_conversions_impl.h"
+
+namespace base {
+namespace internal {
+
+// Fast saturation to a destination type.
+template <typename Dst, typename Src>
+struct SaturateFastAsmOp {
+  static constexpr bool is_supported =
+      kEnableAsmCode && std::is_signed_v<Src> && std::is_integral_v<Dst> &&
+      std::is_integral_v<Src> &&
+      IntegerBitsPlusSign<Src>::value <= IntegerBitsPlusSign<int32_t>::value &&
+      IntegerBitsPlusSign<Dst>::value <= IntegerBitsPlusSign<int32_t>::value &&
+      !IsTypeInRangeForNumericType<Dst, Src>::value;
+
+  __attribute__((always_inline)) static Dst Do(Src value) {
+    int32_t src = value;
+    typename std::conditional<std::is_signed_v<Dst>, int32_t, uint32_t>::type
+        result;
+    if (std::is_signed_v<Dst>) {
+      asm("ssat %[dst], %[shift], %[src]"
+          : [dst] "=r"(result)
+          : [src] "r"(src), [shift] "n"(IntegerBitsPlusSign<Dst>::value <= 32
+                                            ? IntegerBitsPlusSign<Dst>::value
+                                            : 32));
+    } else {
+      asm("usat %[dst], %[shift], %[src]"
+          : [dst] "=r"(result)
+          : [src] "r"(src), [shift] "n"(IntegerBitsPlusSign<Dst>::value < 32
+                                            ? IntegerBitsPlusSign<Dst>::value
+                                            : 31));
+    }
+    return static_cast<Dst>(result);
+  }
+};
+
+}  // namespace internal
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_CONVERSIONS_ARM_IMPL_H_

--- a/internal/base/numerics/safe_conversions_impl.h
+++ b/internal/base/numerics/safe_conversions_impl.h
@@ -1,0 +1,842 @@
+// Copyright 2014 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_CONVERSIONS_IMPL_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_CONVERSIONS_IMPL_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+// IWYU pragma: private, include "base/numerics/safe_conversions.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <concepts>
+#include <limits>
+#include <type_traits>
+
+#if defined(__GNUC__) || defined(__clang__)
+#define BASE_NUMERICS_LIKELY(x) __builtin_expect(!!(x), 1)
+#define BASE_NUMERICS_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#define BASE_NUMERICS_LIKELY(x) (x)
+#define BASE_NUMERICS_UNLIKELY(x) (x)
+#endif
+
+namespace base {
+namespace internal {
+
+// The std library doesn't provide a binary max_exponent for integers, however
+// we can compute an analog using std::numeric_limits<>::digits.
+template <typename NumericType>
+struct MaxExponent {
+  static const int value = std::is_floating_point_v<NumericType>
+                               ? std::numeric_limits<NumericType>::max_exponent
+                               : std::numeric_limits<NumericType>::digits + 1;
+};
+
+// The number of bits (including the sign) in an integer. Eliminates sizeof
+// hacks.
+template <typename NumericType>
+struct IntegerBitsPlusSign {
+  static const int value =
+      std::numeric_limits<NumericType>::digits + std::is_signed_v<NumericType>;
+};
+
+// Helper templates for integer manipulations.
+
+template <typename Integer>
+struct PositionOfSignBit {
+  static const size_t value = IntegerBitsPlusSign<Integer>::value - 1;
+};
+
+// Determines if a numeric value is negative without throwing compiler
+// warnings on: unsigned(value) < 0.
+template <typename T>
+  requires(std::is_arithmetic_v<T> && std::is_signed_v<T>)
+constexpr bool IsValueNegative(T value) {
+  return value < 0;
+}
+
+template <typename T>
+  requires(std::is_arithmetic_v<T> && std::is_unsigned_v<T>)
+constexpr bool IsValueNegative(T) {
+  return false;
+}
+
+// This performs a fast negation, returning a signed value. It works on unsigned
+// arguments, but probably doesn't do what you want for any unsigned value
+// larger than max / 2 + 1 (i.e. signed min cast to unsigned).
+template <typename T>
+constexpr typename std::make_signed<T>::type ConditionalNegate(
+    T x,
+    bool is_negative) {
+  static_assert(std::is_integral_v<T>, "Type must be integral");
+  using SignedT = typename std::make_signed<T>::type;
+  using UnsignedT = typename std::make_unsigned<T>::type;
+  return static_cast<SignedT>((static_cast<UnsignedT>(x) ^
+                               static_cast<UnsignedT>(-SignedT(is_negative))) +
+                              is_negative);
+}
+
+// This performs a safe, absolute value via unsigned overflow.
+template <typename T>
+constexpr typename std::make_unsigned<T>::type SafeUnsignedAbs(T value) {
+  static_assert(std::is_integral_v<T>, "Type must be integral");
+  using UnsignedT = typename std::make_unsigned<T>::type;
+  return IsValueNegative(value)
+             ? static_cast<UnsignedT>(0u - static_cast<UnsignedT>(value))
+             : static_cast<UnsignedT>(value);
+}
+
+// TODO(jschuh): Switch to std::is_constant_evaluated() once C++20 is supported.
+// Alternately, the usage could be restructured for "consteval if" in C++23.
+#define IsConstantEvaluated() (__builtin_is_constant_evaluated())
+
+// TODO(jschuh): Debug builds don't reliably propagate constants, so we restrict
+// some accelerated runtime paths to release builds until this can be forced
+// with consteval support in C++20 or C++23.
+#if defined(NDEBUG)
+constexpr bool kEnableAsmCode = true;
+#else
+constexpr bool kEnableAsmCode = false;
+#endif
+
+// Forces a crash, like a CHECK(false). Used for numeric boundary errors.
+// Also used in a constexpr template to trigger a compilation failure on
+// an error condition.
+struct CheckOnFailure {
+  template <typename T>
+  static T HandleFailure() {
+#if defined(_MSC_VER)
+    __debugbreak();
+#elif defined(__GNUC__) || defined(__clang__)
+    __builtin_trap();
+#else
+    ((void)(*(volatile char*)0 = 0));
+#endif
+    return T();
+  }
+};
+
+enum IntegerRepresentation {
+  INTEGER_REPRESENTATION_UNSIGNED,
+  INTEGER_REPRESENTATION_SIGNED
+};
+
+// A range for a given nunmeric Src type is contained for a given numeric Dst
+// type if both numeric_limits<Src>::max() <= numeric_limits<Dst>::max() and
+// numeric_limits<Src>::lowest() >= numeric_limits<Dst>::lowest() are true.
+// We implement this as template specializations rather than simple static
+// comparisons to ensure type correctness in our comparisons.
+enum NumericRangeRepresentation {
+  NUMERIC_RANGE_NOT_CONTAINED,
+  NUMERIC_RANGE_CONTAINED
+};
+
+// Helper templates to statically determine if our destination type can contain
+// maximum and minimum values represented by the source type.
+
+template <typename Dst,
+          typename Src,
+          IntegerRepresentation DstSign = std::is_signed_v<Dst>
+                                              ? INTEGER_REPRESENTATION_SIGNED
+                                              : INTEGER_REPRESENTATION_UNSIGNED,
+          IntegerRepresentation SrcSign = std::is_signed_v<Src>
+                                              ? INTEGER_REPRESENTATION_SIGNED
+                                              : INTEGER_REPRESENTATION_UNSIGNED>
+struct StaticDstRangeRelationToSrcRange;
+
+// Same sign: Dst is guaranteed to contain Src only if its range is equal or
+// larger.
+template <typename Dst, typename Src, IntegerRepresentation Sign>
+struct StaticDstRangeRelationToSrcRange<Dst, Src, Sign, Sign> {
+  static const NumericRangeRepresentation value =
+      MaxExponent<Dst>::value >= MaxExponent<Src>::value
+          ? NUMERIC_RANGE_CONTAINED
+          : NUMERIC_RANGE_NOT_CONTAINED;
+};
+
+// Unsigned to signed: Dst is guaranteed to contain source only if its range is
+// larger.
+template <typename Dst, typename Src>
+struct StaticDstRangeRelationToSrcRange<Dst,
+                                        Src,
+                                        INTEGER_REPRESENTATION_SIGNED,
+                                        INTEGER_REPRESENTATION_UNSIGNED> {
+  static const NumericRangeRepresentation value =
+      MaxExponent<Dst>::value > MaxExponent<Src>::value
+          ? NUMERIC_RANGE_CONTAINED
+          : NUMERIC_RANGE_NOT_CONTAINED;
+};
+
+// Signed to unsigned: Dst cannot be statically determined to contain Src.
+template <typename Dst, typename Src>
+struct StaticDstRangeRelationToSrcRange<Dst,
+                                        Src,
+                                        INTEGER_REPRESENTATION_UNSIGNED,
+                                        INTEGER_REPRESENTATION_SIGNED> {
+  static const NumericRangeRepresentation value = NUMERIC_RANGE_NOT_CONTAINED;
+};
+
+// This class wraps the range constraints as separate booleans so the compiler
+// can identify constants and eliminate unused code paths.
+class RangeCheck {
+ public:
+  constexpr RangeCheck(bool is_in_lower_bound, bool is_in_upper_bound)
+      : is_underflow_(!is_in_lower_bound), is_overflow_(!is_in_upper_bound) {}
+  constexpr RangeCheck() : is_underflow_(false), is_overflow_(false) {}
+  constexpr bool IsValid() const { return !is_overflow_ && !is_underflow_; }
+  constexpr bool IsInvalid() const { return is_overflow_ && is_underflow_; }
+  constexpr bool IsOverflow() const { return is_overflow_ && !is_underflow_; }
+  constexpr bool IsUnderflow() const { return !is_overflow_ && is_underflow_; }
+  constexpr bool IsOverflowFlagSet() const { return is_overflow_; }
+  constexpr bool IsUnderflowFlagSet() const { return is_underflow_; }
+  constexpr bool operator==(const RangeCheck rhs) const {
+    return is_underflow_ == rhs.is_underflow_ &&
+           is_overflow_ == rhs.is_overflow_;
+  }
+  constexpr bool operator!=(const RangeCheck rhs) const {
+    return !(*this == rhs);
+  }
+
+ private:
+  // Do not change the order of these member variables. The integral conversion
+  // optimization depends on this exact order.
+  const bool is_underflow_;
+  const bool is_overflow_;
+};
+
+// The following helper template addresses a corner case in range checks for
+// conversion from a floating-point type to an integral type of smaller range
+// but larger precision (e.g. float -> unsigned). The problem is as follows:
+//   1. Integral maximum is always one less than a power of two, so it must be
+//      truncated to fit the mantissa of the floating point. The direction of
+//      rounding is implementation defined, but by default it's always IEEE
+//      floats, which round to nearest and thus result in a value of larger
+//      magnitude than the integral value.
+//      Example: float f = UINT_MAX; // f is 4294967296f but UINT_MAX
+//                                   // is 4294967295u.
+//   2. If the floating point value is equal to the promoted integral maximum
+//      value, a range check will erroneously pass.
+//      Example: (4294967296f <= 4294967295u) // This is true due to a precision
+//                                            // loss in rounding up to float.
+//   3. When the floating point value is then converted to an integral, the
+//      resulting value is out of range for the target integral type and
+//      thus is implementation defined.
+//      Example: unsigned u = (float)INT_MAX; // u will typically overflow to 0.
+// To fix this bug we manually truncate the maximum value when the destination
+// type is an integral of larger precision than the source floating-point type,
+// such that the resulting maximum is represented exactly as a floating point.
+template <typename Dst, typename Src, template <typename> class Bounds>
+struct NarrowingRange {
+  using SrcLimits = std::numeric_limits<Src>;
+  using DstLimits = typename std::numeric_limits<Dst>;
+
+  // Computes the mask required to make an accurate comparison between types.
+  static const int kShift =
+      (MaxExponent<Src>::value > MaxExponent<Dst>::value &&
+       SrcLimits::digits < DstLimits::digits)
+          ? (DstLimits::digits - SrcLimits::digits)
+          : 0;
+
+  template <typename T>
+    requires(std::integral<T>)
+  // Masks out the integer bits that are beyond the precision of the
+  // intermediate type used for comparison.
+  static constexpr T Adjust(T value) {
+    static_assert(std::is_same_v<T, Dst>, "");
+    static_assert(kShift < DstLimits::digits, "");
+    using UnsignedDst = typename std::make_unsigned_t<T>;
+    return static_cast<T>(ConditionalNegate(
+        SafeUnsignedAbs(value) & ~((UnsignedDst{1} << kShift) - UnsignedDst{1}),
+        IsValueNegative(value)));
+  }
+
+  template <typename T>
+    requires(std::floating_point<T>)
+  static constexpr T Adjust(T value) {
+    static_assert(std::is_same_v<T, Dst>, "");
+    static_assert(kShift == 0, "");
+    return value;
+  }
+
+  static constexpr Dst max() { return Adjust(Bounds<Dst>::max()); }
+  static constexpr Dst lowest() { return Adjust(Bounds<Dst>::lowest()); }
+};
+
+template <typename Dst,
+          typename Src,
+          template <typename>
+          class Bounds,
+          IntegerRepresentation DstSign = std::is_signed_v<Dst>
+                                              ? INTEGER_REPRESENTATION_SIGNED
+                                              : INTEGER_REPRESENTATION_UNSIGNED,
+          IntegerRepresentation SrcSign = std::is_signed_v<Src>
+                                              ? INTEGER_REPRESENTATION_SIGNED
+                                              : INTEGER_REPRESENTATION_UNSIGNED,
+          NumericRangeRepresentation DstRange =
+              StaticDstRangeRelationToSrcRange<Dst, Src>::value>
+struct DstRangeRelationToSrcRangeImpl;
+
+// The following templates are for ranges that must be verified at runtime. We
+// split it into checks based on signedness to avoid confusing casts and
+// compiler warnings on signed an unsigned comparisons.
+
+// Same sign narrowing: The range is contained for normal limits.
+template <typename Dst,
+          typename Src,
+          template <typename>
+          class Bounds,
+          IntegerRepresentation DstSign,
+          IntegerRepresentation SrcSign>
+struct DstRangeRelationToSrcRangeImpl<Dst,
+                                      Src,
+                                      Bounds,
+                                      DstSign,
+                                      SrcSign,
+                                      NUMERIC_RANGE_CONTAINED> {
+  static constexpr RangeCheck Check(Src value) {
+    using SrcLimits = std::numeric_limits<Src>;
+    using DstLimits = NarrowingRange<Dst, Src, Bounds>;
+    return RangeCheck(
+        static_cast<Dst>(SrcLimits::lowest()) >= DstLimits::lowest() ||
+            static_cast<Dst>(value) >= DstLimits::lowest(),
+        static_cast<Dst>(SrcLimits::max()) <= DstLimits::max() ||
+            static_cast<Dst>(value) <= DstLimits::max());
+  }
+};
+
+// Signed to signed narrowing: Both the upper and lower boundaries may be
+// exceeded for standard limits.
+template <typename Dst, typename Src, template <typename> class Bounds>
+struct DstRangeRelationToSrcRangeImpl<Dst,
+                                      Src,
+                                      Bounds,
+                                      INTEGER_REPRESENTATION_SIGNED,
+                                      INTEGER_REPRESENTATION_SIGNED,
+                                      NUMERIC_RANGE_NOT_CONTAINED> {
+  static constexpr RangeCheck Check(Src value) {
+    using DstLimits = NarrowingRange<Dst, Src, Bounds>;
+    return RangeCheck(value >= DstLimits::lowest(), value <= DstLimits::max());
+  }
+};
+
+// Unsigned to unsigned narrowing: Only the upper bound can be exceeded for
+// standard limits.
+template <typename Dst, typename Src, template <typename> class Bounds>
+struct DstRangeRelationToSrcRangeImpl<Dst,
+                                      Src,
+                                      Bounds,
+                                      INTEGER_REPRESENTATION_UNSIGNED,
+                                      INTEGER_REPRESENTATION_UNSIGNED,
+                                      NUMERIC_RANGE_NOT_CONTAINED> {
+  static constexpr RangeCheck Check(Src value) {
+    using DstLimits = NarrowingRange<Dst, Src, Bounds>;
+    return RangeCheck(
+        DstLimits::lowest() == Dst(0) || value >= DstLimits::lowest(),
+        value <= DstLimits::max());
+  }
+};
+
+// Unsigned to signed: Only the upper bound can be exceeded for standard limits.
+template <typename Dst, typename Src, template <typename> class Bounds>
+struct DstRangeRelationToSrcRangeImpl<Dst,
+                                      Src,
+                                      Bounds,
+                                      INTEGER_REPRESENTATION_SIGNED,
+                                      INTEGER_REPRESENTATION_UNSIGNED,
+                                      NUMERIC_RANGE_NOT_CONTAINED> {
+  static constexpr RangeCheck Check(Src value) {
+    using DstLimits = NarrowingRange<Dst, Src, Bounds>;
+    using Promotion = decltype(Src() + Dst());
+    return RangeCheck(DstLimits::lowest() <= Dst(0) ||
+                          static_cast<Promotion>(value) >=
+                              static_cast<Promotion>(DstLimits::lowest()),
+                      static_cast<Promotion>(value) <=
+                          static_cast<Promotion>(DstLimits::max()));
+  }
+};
+
+// Signed to unsigned: The upper boundary may be exceeded for a narrower Dst,
+// and any negative value exceeds the lower boundary for standard limits.
+template <typename Dst, typename Src, template <typename> class Bounds>
+struct DstRangeRelationToSrcRangeImpl<Dst,
+                                      Src,
+                                      Bounds,
+                                      INTEGER_REPRESENTATION_UNSIGNED,
+                                      INTEGER_REPRESENTATION_SIGNED,
+                                      NUMERIC_RANGE_NOT_CONTAINED> {
+  static constexpr RangeCheck Check(Src value) {
+    using SrcLimits = std::numeric_limits<Src>;
+    using DstLimits = NarrowingRange<Dst, Src, Bounds>;
+    using Promotion = decltype(Src() + Dst());
+    bool ge_zero = false;
+    // Converting floating-point to integer will discard fractional part, so
+    // values in (-1.0, -0.0) will truncate to 0 and fit in Dst.
+    if (std::is_floating_point_v<Src>) {
+      ge_zero = value > Src(-1);
+    } else {
+      ge_zero = value >= Src(0);
+    }
+    return RangeCheck(
+        ge_zero && (DstLimits::lowest() == 0 ||
+                    static_cast<Dst>(value) >= DstLimits::lowest()),
+        static_cast<Promotion>(SrcLimits::max()) <=
+                static_cast<Promotion>(DstLimits::max()) ||
+            static_cast<Promotion>(value) <=
+                static_cast<Promotion>(DstLimits::max()));
+  }
+};
+
+// Simple wrapper for statically checking if a type's range is contained.
+template <typename Dst, typename Src>
+struct IsTypeInRangeForNumericType {
+  static const bool value = StaticDstRangeRelationToSrcRange<Dst, Src>::value ==
+                            NUMERIC_RANGE_CONTAINED;
+};
+
+template <typename Dst,
+          template <typename> class Bounds = std::numeric_limits,
+          typename Src>
+constexpr RangeCheck DstRangeRelationToSrcRange(Src value) {
+  static_assert(std::is_arithmetic_v<Src>, "Argument must be numeric.");
+  static_assert(std::is_arithmetic_v<Dst>, "Result must be numeric.");
+  static_assert(Bounds<Dst>::lowest() < Bounds<Dst>::max(), "");
+  return DstRangeRelationToSrcRangeImpl<Dst, Src, Bounds>::Check(value);
+}
+
+// Integer promotion templates used by the portable checked integer arithmetic.
+template <size_t Size, bool IsSigned>
+struct IntegerForDigitsAndSign;
+
+#define INTEGER_FOR_DIGITS_AND_SIGN(I)                          \
+  template <>                                                   \
+  struct IntegerForDigitsAndSign<IntegerBitsPlusSign<I>::value, \
+                                 std::is_signed_v<I>> {         \
+    using type = I;                                             \
+  }
+
+INTEGER_FOR_DIGITS_AND_SIGN(int8_t);
+INTEGER_FOR_DIGITS_AND_SIGN(uint8_t);
+INTEGER_FOR_DIGITS_AND_SIGN(int16_t);
+INTEGER_FOR_DIGITS_AND_SIGN(uint16_t);
+INTEGER_FOR_DIGITS_AND_SIGN(int32_t);
+INTEGER_FOR_DIGITS_AND_SIGN(uint32_t);
+INTEGER_FOR_DIGITS_AND_SIGN(int64_t);
+INTEGER_FOR_DIGITS_AND_SIGN(uint64_t);
+#undef INTEGER_FOR_DIGITS_AND_SIGN
+
+// WARNING: We have no IntegerForSizeAndSign<16, *>. If we ever add one to
+// support 128-bit math, then the ArithmeticPromotion template below will need
+// to be updated (or more likely replaced with a decltype expression).
+static_assert(IntegerBitsPlusSign<intmax_t>::value == 64,
+              "Max integer size not supported for this toolchain.");
+
+template <typename Integer, bool IsSigned = std::is_signed_v<Integer>>
+struct TwiceWiderInteger {
+  using type =
+      typename IntegerForDigitsAndSign<IntegerBitsPlusSign<Integer>::value * 2,
+                                       IsSigned>::type;
+};
+
+enum ArithmeticPromotionCategory {
+  LEFT_PROMOTION,  // Use the type of the left-hand argument.
+  RIGHT_PROMOTION  // Use the type of the right-hand argument.
+};
+
+// Determines the type that can represent the largest positive value.
+template <typename Lhs,
+          typename Rhs,
+          ArithmeticPromotionCategory Promotion =
+              (MaxExponent<Lhs>::value > MaxExponent<Rhs>::value)
+                  ? LEFT_PROMOTION
+                  : RIGHT_PROMOTION>
+struct MaxExponentPromotion;
+
+template <typename Lhs, typename Rhs>
+struct MaxExponentPromotion<Lhs, Rhs, LEFT_PROMOTION> {
+  using type = Lhs;
+};
+
+template <typename Lhs, typename Rhs>
+struct MaxExponentPromotion<Lhs, Rhs, RIGHT_PROMOTION> {
+  using type = Rhs;
+};
+
+// Determines the type that can represent the lowest arithmetic value.
+template <typename Lhs,
+          typename Rhs,
+          ArithmeticPromotionCategory Promotion =
+              std::is_signed_v<Lhs>
+                  ? (std::is_signed_v<Rhs>
+                         ? (MaxExponent<Lhs>::value > MaxExponent<Rhs>::value
+                                ? LEFT_PROMOTION
+                                : RIGHT_PROMOTION)
+                         : LEFT_PROMOTION)
+                  : (std::is_signed_v<Rhs>
+                         ? RIGHT_PROMOTION
+                         : (MaxExponent<Lhs>::value < MaxExponent<Rhs>::value
+                                ? LEFT_PROMOTION
+                                : RIGHT_PROMOTION))>
+struct LowestValuePromotion;
+
+template <typename Lhs, typename Rhs>
+struct LowestValuePromotion<Lhs, Rhs, LEFT_PROMOTION> {
+  using type = Lhs;
+};
+
+template <typename Lhs, typename Rhs>
+struct LowestValuePromotion<Lhs, Rhs, RIGHT_PROMOTION> {
+  using type = Rhs;
+};
+
+// Determines the type that is best able to represent an arithmetic result.
+template <
+    typename Lhs,
+    typename Rhs = Lhs,
+    bool is_intmax_type =
+        std::is_integral_v<typename MaxExponentPromotion<Lhs, Rhs>::type> &&
+        IntegerBitsPlusSign<typename MaxExponentPromotion<Lhs, Rhs>::type>::
+                value == IntegerBitsPlusSign<intmax_t>::value,
+    bool is_max_exponent = StaticDstRangeRelationToSrcRange<
+                               typename MaxExponentPromotion<Lhs, Rhs>::type,
+                               Lhs>::value == NUMERIC_RANGE_CONTAINED &&
+                           StaticDstRangeRelationToSrcRange<
+                               typename MaxExponentPromotion<Lhs, Rhs>::type,
+                               Rhs>::value == NUMERIC_RANGE_CONTAINED>
+struct BigEnoughPromotion;
+
+// The side with the max exponent is big enough.
+template <typename Lhs, typename Rhs, bool is_intmax_type>
+struct BigEnoughPromotion<Lhs, Rhs, is_intmax_type, true> {
+  using type = typename MaxExponentPromotion<Lhs, Rhs>::type;
+  static const bool is_contained = true;
+};
+
+// We can use a twice wider type to fit.
+template <typename Lhs, typename Rhs>
+struct BigEnoughPromotion<Lhs, Rhs, false, false> {
+  using type =
+      typename TwiceWiderInteger<typename MaxExponentPromotion<Lhs, Rhs>::type,
+                                 std::is_signed_v<Lhs> ||
+                                     std::is_signed_v<Rhs>>::type;
+  static const bool is_contained = true;
+};
+
+// No type is large enough.
+template <typename Lhs, typename Rhs>
+struct BigEnoughPromotion<Lhs, Rhs, true, false> {
+  using type = typename MaxExponentPromotion<Lhs, Rhs>::type;
+  static const bool is_contained = false;
+};
+
+// We can statically check if operations on the provided types can wrap, so we
+// can skip the checked operations if they're not needed. So, for an integer we
+// care if the destination type preserves the sign and is twice the width of
+// the source.
+template <typename T, typename Lhs, typename Rhs = Lhs>
+struct IsIntegerArithmeticSafe {
+  static const bool value =
+      !std::is_floating_point_v<T> && !std::is_floating_point_v<Lhs> &&
+      !std::is_floating_point_v<Rhs> &&
+      std::is_signed_v<T> >= std::is_signed_v<Lhs> &&
+      IntegerBitsPlusSign<T>::value >= (2 * IntegerBitsPlusSign<Lhs>::value) &&
+      std::is_signed_v<T> >= std::is_signed_v<Rhs> &&
+      IntegerBitsPlusSign<T>::value >= (2 * IntegerBitsPlusSign<Rhs>::value);
+};
+
+// Promotes to a type that can represent any possible result of a binary
+// arithmetic operation with the source types.
+template <typename Lhs, typename Rhs>
+struct FastIntegerArithmeticPromotion {
+  using type = typename BigEnoughPromotion<Lhs, Rhs>::type;
+  static const bool is_contained = false;
+};
+
+template <typename Lhs, typename Rhs>
+  requires(IsIntegerArithmeticSafe<
+           std::conditional_t<std::is_signed_v<Lhs> || std::is_signed_v<Rhs>,
+                              intmax_t,
+                              uintmax_t>,
+           typename MaxExponentPromotion<Lhs, Rhs>::type>::value)
+struct FastIntegerArithmeticPromotion<Lhs, Rhs> {
+  using type =
+      typename TwiceWiderInteger<typename MaxExponentPromotion<Lhs, Rhs>::type,
+                                 std::is_signed_v<Lhs> ||
+                                     std::is_signed_v<Rhs>>::type;
+  static_assert(IsIntegerArithmeticSafe<type, Lhs, Rhs>::value, "");
+  static const bool is_contained = true;
+};
+
+// Extracts the underlying type from an enum.
+template <typename T>
+struct ArithmeticOrUnderlyingEnum {
+  using type = T;
+  static const bool value = std::is_arithmetic_v<type>;
+};
+
+template <typename T>
+  requires(std::is_enum_v<T>)
+struct ArithmeticOrUnderlyingEnum<T> {
+  using type = typename std::underlying_type<T>::type;
+  static const bool value = std::is_arithmetic_v<type>;
+};
+
+// The following are helper templates used in the CheckedNumeric class.
+template <typename T>
+class CheckedNumeric;
+
+template <typename T>
+class ClampedNumeric;
+
+template <typename T>
+class StrictNumeric;
+
+// Used to treat CheckedNumeric and arithmetic underlying types the same.
+template <typename T>
+struct UnderlyingType {
+  using type = typename ArithmeticOrUnderlyingEnum<T>::type;
+  static const bool is_numeric = std::is_arithmetic_v<type>;
+  static const bool is_checked = false;
+  static const bool is_clamped = false;
+  static const bool is_strict = false;
+};
+
+template <typename T>
+struct UnderlyingType<CheckedNumeric<T>> {
+  using type = T;
+  static const bool is_numeric = true;
+  static const bool is_checked = true;
+  static const bool is_clamped = false;
+  static const bool is_strict = false;
+};
+
+template <typename T>
+struct UnderlyingType<ClampedNumeric<T>> {
+  using type = T;
+  static const bool is_numeric = true;
+  static const bool is_checked = false;
+  static const bool is_clamped = true;
+  static const bool is_strict = false;
+};
+
+template <typename T>
+struct UnderlyingType<StrictNumeric<T>> {
+  using type = T;
+  static const bool is_numeric = true;
+  static const bool is_checked = false;
+  static const bool is_clamped = false;
+  static const bool is_strict = true;
+};
+
+template <typename L, typename R>
+struct IsCheckedOp {
+  static const bool value =
+      UnderlyingType<L>::is_numeric && UnderlyingType<R>::is_numeric &&
+      (UnderlyingType<L>::is_checked || UnderlyingType<R>::is_checked);
+};
+
+template <typename L, typename R>
+struct IsClampedOp {
+  static const bool value =
+      UnderlyingType<L>::is_numeric && UnderlyingType<R>::is_numeric &&
+      (UnderlyingType<L>::is_clamped || UnderlyingType<R>::is_clamped) &&
+      !(UnderlyingType<L>::is_checked || UnderlyingType<R>::is_checked);
+};
+
+template <typename L, typename R>
+struct IsStrictOp {
+  static const bool value =
+      UnderlyingType<L>::is_numeric && UnderlyingType<R>::is_numeric &&
+      (UnderlyingType<L>::is_strict || UnderlyingType<R>::is_strict) &&
+      !(UnderlyingType<L>::is_checked || UnderlyingType<R>::is_checked) &&
+      !(UnderlyingType<L>::is_clamped || UnderlyingType<R>::is_clamped);
+};
+
+// as_signed<> returns the supplied integral value (or integral castable
+// Numeric template) cast as a signed integral of equivalent precision.
+// I.e. it's mostly an alias for: static_cast<std::make_signed<T>::type>(t)
+template <typename Src>
+constexpr typename std::make_signed<
+    typename base::internal::UnderlyingType<Src>::type>::type
+as_signed(const Src value) {
+  static_assert(std::is_integral_v<decltype(as_signed(value))>,
+                "Argument must be a signed or unsigned integer type.");
+  return static_cast<decltype(as_signed(value))>(value);
+}
+
+// as_unsigned<> returns the supplied integral value (or integral castable
+// Numeric template) cast as an unsigned integral of equivalent precision.
+// I.e. it's mostly an alias for: static_cast<std::make_unsigned<T>::type>(t)
+template <typename Src>
+constexpr typename std::make_unsigned<
+    typename base::internal::UnderlyingType<Src>::type>::type
+as_unsigned(const Src value) {
+  static_assert(std::is_integral_v<decltype(as_unsigned(value))>,
+                "Argument must be a signed or unsigned integer type.");
+  return static_cast<decltype(as_unsigned(value))>(value);
+}
+
+template <typename L, typename R>
+constexpr bool IsLessImpl(const L lhs,
+                          const R rhs,
+                          const RangeCheck l_range,
+                          const RangeCheck r_range) {
+  return l_range.IsUnderflow() || r_range.IsOverflow() ||
+         (l_range == r_range && static_cast<decltype(lhs + rhs)>(lhs) <
+                                    static_cast<decltype(lhs + rhs)>(rhs));
+}
+
+template <typename L, typename R>
+struct IsLess {
+  static_assert(std::is_arithmetic_v<L> && std::is_arithmetic_v<R>,
+                "Types must be numeric.");
+  static constexpr bool Test(const L lhs, const R rhs) {
+    return IsLessImpl(lhs, rhs, DstRangeRelationToSrcRange<R>(lhs),
+                      DstRangeRelationToSrcRange<L>(rhs));
+  }
+};
+
+template <typename L, typename R>
+constexpr bool IsLessOrEqualImpl(const L lhs,
+                                 const R rhs,
+                                 const RangeCheck l_range,
+                                 const RangeCheck r_range) {
+  return l_range.IsUnderflow() || r_range.IsOverflow() ||
+         (l_range == r_range && static_cast<decltype(lhs + rhs)>(lhs) <=
+                                    static_cast<decltype(lhs + rhs)>(rhs));
+}
+
+template <typename L, typename R>
+struct IsLessOrEqual {
+  static_assert(std::is_arithmetic_v<L> && std::is_arithmetic_v<R>,
+                "Types must be numeric.");
+  static constexpr bool Test(const L lhs, const R rhs) {
+    return IsLessOrEqualImpl(lhs, rhs, DstRangeRelationToSrcRange<R>(lhs),
+                             DstRangeRelationToSrcRange<L>(rhs));
+  }
+};
+
+template <typename L, typename R>
+constexpr bool IsGreaterImpl(const L lhs,
+                             const R rhs,
+                             const RangeCheck l_range,
+                             const RangeCheck r_range) {
+  return l_range.IsOverflow() || r_range.IsUnderflow() ||
+         (l_range == r_range && static_cast<decltype(lhs + rhs)>(lhs) >
+                                    static_cast<decltype(lhs + rhs)>(rhs));
+}
+
+template <typename L, typename R>
+struct IsGreater {
+  static_assert(std::is_arithmetic_v<L> && std::is_arithmetic_v<R>,
+                "Types must be numeric.");
+  static constexpr bool Test(const L lhs, const R rhs) {
+    return IsGreaterImpl(lhs, rhs, DstRangeRelationToSrcRange<R>(lhs),
+                         DstRangeRelationToSrcRange<L>(rhs));
+  }
+};
+
+template <typename L, typename R>
+constexpr bool IsGreaterOrEqualImpl(const L lhs,
+                                    const R rhs,
+                                    const RangeCheck l_range,
+                                    const RangeCheck r_range) {
+  return l_range.IsOverflow() || r_range.IsUnderflow() ||
+         (l_range == r_range && static_cast<decltype(lhs + rhs)>(lhs) >=
+                                    static_cast<decltype(lhs + rhs)>(rhs));
+}
+
+template <typename L, typename R>
+struct IsGreaterOrEqual {
+  static_assert(std::is_arithmetic_v<L> && std::is_arithmetic_v<R>,
+                "Types must be numeric.");
+  static constexpr bool Test(const L lhs, const R rhs) {
+    return IsGreaterOrEqualImpl(lhs, rhs, DstRangeRelationToSrcRange<R>(lhs),
+                                DstRangeRelationToSrcRange<L>(rhs));
+  }
+};
+
+template <typename L, typename R>
+struct IsEqual {
+  static_assert(std::is_arithmetic_v<L> && std::is_arithmetic_v<R>,
+                "Types must be numeric.");
+  static constexpr bool Test(const L lhs, const R rhs) {
+    return DstRangeRelationToSrcRange<R>(lhs) ==
+               DstRangeRelationToSrcRange<L>(rhs) &&
+           static_cast<decltype(lhs + rhs)>(lhs) ==
+               static_cast<decltype(lhs + rhs)>(rhs);
+  }
+};
+
+template <typename L, typename R>
+struct IsNotEqual {
+  static_assert(std::is_arithmetic_v<L> && std::is_arithmetic_v<R>,
+                "Types must be numeric.");
+  static constexpr bool Test(const L lhs, const R rhs) {
+    return DstRangeRelationToSrcRange<R>(lhs) !=
+               DstRangeRelationToSrcRange<L>(rhs) ||
+           static_cast<decltype(lhs + rhs)>(lhs) !=
+               static_cast<decltype(lhs + rhs)>(rhs);
+  }
+};
+
+// These perform the actual math operations on the CheckedNumerics.
+// Binary arithmetic operations.
+template <template <typename, typename> class C, typename L, typename R>
+constexpr bool SafeCompare(const L lhs, const R rhs) {
+  static_assert(std::is_arithmetic_v<L> && std::is_arithmetic_v<R>,
+                "Types must be numeric.");
+  using Promotion = BigEnoughPromotion<L, R>;
+  using BigType = typename Promotion::type;
+  return Promotion::is_contained
+             // Force to a larger type for speed if both are contained.
+             ? C<BigType, BigType>::Test(
+                   static_cast<BigType>(static_cast<L>(lhs)),
+                   static_cast<BigType>(static_cast<R>(rhs)))
+             // Let the template functions figure it out for mixed types.
+             : C<L, R>::Test(lhs, rhs);
+}
+
+template <typename Dst, typename Src>
+constexpr bool IsMaxInRangeForNumericType() {
+  return IsGreaterOrEqual<Dst, Src>::Test(std::numeric_limits<Dst>::max(),
+                                          std::numeric_limits<Src>::max());
+}
+
+template <typename Dst, typename Src>
+constexpr bool IsMinInRangeForNumericType() {
+  return IsLessOrEqual<Dst, Src>::Test(std::numeric_limits<Dst>::lowest(),
+                                       std::numeric_limits<Src>::lowest());
+}
+
+template <typename Dst, typename Src>
+constexpr Dst CommonMax() {
+  return !IsMaxInRangeForNumericType<Dst, Src>()
+             ? Dst(std::numeric_limits<Dst>::max())
+             : Dst(std::numeric_limits<Src>::max());
+}
+
+template <typename Dst, typename Src>
+constexpr Dst CommonMin() {
+  return !IsMinInRangeForNumericType<Dst, Src>()
+             ? Dst(std::numeric_limits<Dst>::lowest())
+             : Dst(std::numeric_limits<Src>::lowest());
+}
+
+// This is a wrapper to generate return the max or min for a supplied type.
+// If the argument is false, the returned value is the maximum. If true the
+// returned value is the minimum.
+template <typename Dst, typename Src = Dst>
+constexpr Dst CommonMaxOrMin(bool is_min) {
+  return is_min ? CommonMin<Dst, Src>() : CommonMax<Dst, Src>();
+}
+
+}  // namespace internal
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_CONVERSIONS_IMPL_H_

--- a/internal/base/numerics/safe_math.h
+++ b/internal/base/numerics/safe_math.h
@@ -1,0 +1,16 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_MATH_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_MATH_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include "internal/base/numerics/checked_math.h"      // IWYU pragma: export
+#include "internal/base/numerics/clamped_math.h"      // IWYU pragma: export
+#include "internal/base/numerics/safe_conversions.h"  // IWYU pragma: export
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_MATH_H_

--- a/internal/base/numerics/safe_math_arm_impl.h
+++ b/internal/base/numerics/safe_math_arm_impl.h
@@ -1,0 +1,131 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_MATH_ARM_IMPL_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_MATH_ARM_IMPL_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+// IWYU pragma: private
+
+#include <stdint.h>
+#include <cassert>
+
+#include "internal/base/numerics/safe_conversions.h"
+
+namespace base {
+namespace internal {
+
+template <typename T, typename U>
+struct CheckedMulFastAsmOp {
+  static const bool is_supported =
+      kEnableAsmCode && FastIntegerArithmeticPromotion<T, U>::is_contained;
+
+  // The following is not an assembler routine and is thus constexpr safe, it
+  // just emits much more efficient code than the Clang and GCC builtins for
+  // performing overflow-checked multiplication when a twice wider type is
+  // available. The below compiles down to 2-3 instructions, depending on the
+  // width of the types in use.
+  // As an example, an int32_t multiply compiles to:
+  //    smull   r0, r1, r0, r1
+  //    cmp     r1, r1, asr #31
+  // And an int16_t multiply compiles to:
+  //    smulbb  r1, r1, r0
+  //    asr     r2, r1, #16
+  //    cmp     r2, r1, asr #15
+  template <typename V>
+  static constexpr bool Do(T x, U y, V* result) {
+    using Promotion = typename FastIntegerArithmeticPromotion<T, U>::type;
+    Promotion presult;
+
+    presult = static_cast<Promotion>(x) * static_cast<Promotion>(y);
+    if (!IsValueInRangeForNumericType<V>(presult))
+      return false;
+    *result = static_cast<V>(presult);
+    return true;
+  }
+};
+
+template <typename T, typename U>
+struct ClampedAddFastAsmOp {
+  static const bool is_supported =
+      kEnableAsmCode && BigEnoughPromotion<T, U>::is_contained &&
+      IsTypeInRangeForNumericType<
+          int32_t,
+          typename BigEnoughPromotion<T, U>::type>::value;
+
+  template <typename V>
+  __attribute__((always_inline)) static V Do(T x, U y) {
+    // This will get promoted to an int, so let the compiler do whatever is
+    // clever and rely on the saturated cast to bounds check.
+    if (IsIntegerArithmeticSafe<int, T, U>::value)
+      return saturated_cast<V>(static_cast<int>(x) + static_cast<int>(y));
+
+    int32_t result;
+    int32_t x_i32 = checked_cast<int32_t>(x);
+    int32_t y_i32 = checked_cast<int32_t>(y);
+
+    asm("qadd %[result], %[first], %[second]"
+        : [result] "=r"(result)
+        : [first] "r"(x_i32), [second] "r"(y_i32));
+    return saturated_cast<V>(result);
+  }
+};
+
+template <typename T, typename U>
+struct ClampedSubFastAsmOp {
+  static const bool is_supported =
+      kEnableAsmCode && BigEnoughPromotion<T, U>::is_contained &&
+      IsTypeInRangeForNumericType<
+          int32_t,
+          typename BigEnoughPromotion<T, U>::type>::value;
+
+  template <typename V>
+  __attribute__((always_inline)) static V Do(T x, U y) {
+    // This will get promoted to an int, so let the compiler do whatever is
+    // clever and rely on the saturated cast to bounds check.
+    if (IsIntegerArithmeticSafe<int, T, U>::value)
+      return saturated_cast<V>(static_cast<int>(x) - static_cast<int>(y));
+
+    int32_t result;
+    int32_t x_i32 = checked_cast<int32_t>(x);
+    int32_t y_i32 = checked_cast<int32_t>(y);
+
+    asm("qsub %[result], %[first], %[second]"
+        : [result] "=r"(result)
+        : [first] "r"(x_i32), [second] "r"(y_i32));
+    return saturated_cast<V>(result);
+  }
+};
+
+template <typename T, typename U>
+struct ClampedMulFastAsmOp {
+  static const bool is_supported =
+      kEnableAsmCode && CheckedMulFastAsmOp<T, U>::is_supported;
+
+  template <typename V>
+  __attribute__((always_inline)) static V Do(T x, U y) {
+    // Use the CheckedMulFastAsmOp for full-width 32-bit values, because
+    // it's fewer instructions than promoting and then saturating.
+    if (!IsIntegerArithmeticSafe<int32_t, T, U>::value &&
+        !IsIntegerArithmeticSafe<uint32_t, T, U>::value) {
+      V result;
+      return CheckedMulFastAsmOp<T, U>::Do(x, y, &result)
+                 ? result
+                 : CommonMaxOrMin<V>(IsValueNegative(x) ^ IsValueNegative(y));
+    }
+
+    assert((FastIntegerArithmeticPromotion<T, U>::is_contained));
+    using Promotion = typename FastIntegerArithmeticPromotion<T, U>::type;
+    return saturated_cast<V>(static_cast<Promotion>(x) *
+                             static_cast<Promotion>(y));
+  }
+};
+
+}  // namespace internal
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_MATH_ARM_IMPL_H_

--- a/internal/base/numerics/safe_math_clang_gcc_impl.h
+++ b/internal/base/numerics/safe_math_clang_gcc_impl.h
@@ -1,0 +1,163 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_MATH_CLANG_GCC_IMPL_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_MATH_CLANG_GCC_IMPL_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+// IWYU pragma: private
+
+#include <stdint.h>
+#include <limits>
+#include <type_traits>
+
+#include "internal/base/numerics/safe_conversions.h"
+
+#if !defined(__native_client__) && (defined(__ARMEL__) || defined(__arch64__))
+#include "internal/base/numerics/safe_math_arm_impl.h"  // IWYU pragma: export
+#define BASE_HAS_ASSEMBLER_SAFE_MATH (1)
+#else
+#define BASE_HAS_ASSEMBLER_SAFE_MATH (0)
+#endif
+
+namespace base {
+namespace internal {
+
+// These are the non-functioning boilerplate implementations of the optimized
+// safe math routines.
+#if !BASE_HAS_ASSEMBLER_SAFE_MATH
+template <typename T, typename U>
+struct CheckedMulFastAsmOp {
+  static const bool is_supported = false;
+  template <typename V>
+  static constexpr bool Do(T, U, V*) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<bool>();
+  }
+};
+
+template <typename T, typename U>
+struct ClampedAddFastAsmOp {
+  static const bool is_supported = false;
+  template <typename V>
+  static constexpr V Do(T, U) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<V>();
+  }
+};
+
+template <typename T, typename U>
+struct ClampedSubFastAsmOp {
+  static const bool is_supported = false;
+  template <typename V>
+  static constexpr V Do(T, U) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<V>();
+  }
+};
+
+template <typename T, typename U>
+struct ClampedMulFastAsmOp {
+  static const bool is_supported = false;
+  template <typename V>
+  static constexpr V Do(T, U) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<V>();
+  }
+};
+#endif  // BASE_HAS_ASSEMBLER_SAFE_MATH
+#undef BASE_HAS_ASSEMBLER_SAFE_MATH
+
+template <typename T, typename U>
+struct CheckedAddFastOp {
+  static const bool is_supported = true;
+  template <typename V>
+  __attribute__((always_inline)) static constexpr bool Do(T x, U y, V* result) {
+    return !__builtin_add_overflow(x, y, result);
+  }
+};
+
+template <typename T, typename U>
+struct CheckedSubFastOp {
+  static const bool is_supported = true;
+  template <typename V>
+  __attribute__((always_inline)) static constexpr bool Do(T x, U y, V* result) {
+    return !__builtin_sub_overflow(x, y, result);
+  }
+};
+
+template <typename T, typename U>
+struct CheckedMulFastOp {
+#if defined(__clang__)
+  // TODO(jschuh): Get the Clang runtime library issues sorted out so we can
+  // support full-width, mixed-sign multiply builtins.
+  // https://crbug.com/613003
+  // We can support intptr_t, uintptr_t, or a smaller common type.
+  static const bool is_supported =
+      (IsTypeInRangeForNumericType<intptr_t, T>::value &&
+       IsTypeInRangeForNumericType<intptr_t, U>::value) ||
+      (IsTypeInRangeForNumericType<uintptr_t, T>::value &&
+       IsTypeInRangeForNumericType<uintptr_t, U>::value);
+#else
+  static const bool is_supported = true;
+#endif
+  template <typename V>
+  __attribute__((always_inline)) static constexpr bool Do(T x, U y, V* result) {
+    return CheckedMulFastAsmOp<T, U>::is_supported
+               ? CheckedMulFastAsmOp<T, U>::Do(x, y, result)
+               : !__builtin_mul_overflow(x, y, result);
+  }
+};
+
+template <typename T, typename U>
+struct ClampedAddFastOp {
+  static const bool is_supported = ClampedAddFastAsmOp<T, U>::is_supported;
+  template <typename V>
+  __attribute__((always_inline)) static V Do(T x, U y) {
+    return ClampedAddFastAsmOp<T, U>::template Do<V>(x, y);
+  }
+};
+
+template <typename T, typename U>
+struct ClampedSubFastOp {
+  static const bool is_supported = ClampedSubFastAsmOp<T, U>::is_supported;
+  template <typename V>
+  __attribute__((always_inline)) static V Do(T x, U y) {
+    return ClampedSubFastAsmOp<T, U>::template Do<V>(x, y);
+  }
+};
+
+template <typename T, typename U>
+struct ClampedMulFastOp {
+  static const bool is_supported = ClampedMulFastAsmOp<T, U>::is_supported;
+  template <typename V>
+  __attribute__((always_inline)) static V Do(T x, U y) {
+    return ClampedMulFastAsmOp<T, U>::template Do<V>(x, y);
+  }
+};
+
+template <typename T>
+struct ClampedNegFastOp {
+  static const bool is_supported = std::is_signed_v<T>;
+  __attribute__((always_inline)) static T Do(T value) {
+    // Use this when there is no assembler path available.
+    if (!ClampedSubFastAsmOp<T, T>::is_supported) {
+      T result;
+      return !__builtin_sub_overflow(T(0), value, &result)
+                 ? result
+                 : std::numeric_limits<T>::max();
+    }
+
+    // Fallback to the normal subtraction path.
+    return ClampedSubFastOp<T, T>::template Do<T>(T(0), value);
+  }
+};
+
+}  // namespace internal
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_MATH_CLANG_GCC_IMPL_H_

--- a/internal/base/numerics/safe_math_shared_impl.h
+++ b/internal/base/numerics/safe_math_shared_impl.h
@@ -1,0 +1,209 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_MATH_SHARED_IMPL_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_MATH_SHARED_IMPL_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+// IWYU pragma: private
+
+#include <concepts>
+#include <type_traits>
+
+#include "internal/base/numerics/safe_conversions.h"
+#include "internal/build/build_config.h"
+
+#if BUILDFLAG(IS_ASMJS)
+// Optimized safe math instructions are incompatible with asmjs.
+#define BASE_HAS_OPTIMIZED_SAFE_MATH (0)
+// Where available use builtin math overflow support on Clang and GCC.
+#elif !defined(__native_client__) &&                       \
+    ((defined(__clang__) &&                                \
+      ((__clang_major__ > 3) ||                            \
+       (__clang_major__ == 3 && __clang_minor__ >= 4))) || \
+     (defined(__GNUC__) && __GNUC__ >= 5))
+#include "base/numerics/safe_math_clang_gcc_impl.h"  // IWYU pragma: export
+#define BASE_HAS_OPTIMIZED_SAFE_MATH (1)
+#else
+#define BASE_HAS_OPTIMIZED_SAFE_MATH (0)
+#endif
+
+namespace base {
+namespace internal {
+
+// These are the non-functioning boilerplate implementations of the optimized
+// safe math routines.
+#if !BASE_HAS_OPTIMIZED_SAFE_MATH
+template <typename T, typename U>
+struct CheckedAddFastOp {
+  static const bool is_supported = false;
+  template <typename V>
+  static constexpr bool Do(T, U, V*) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<bool>();
+  }
+};
+
+template <typename T, typename U>
+struct CheckedSubFastOp {
+  static const bool is_supported = false;
+  template <typename V>
+  static constexpr bool Do(T, U, V*) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<bool>();
+  }
+};
+
+template <typename T, typename U>
+struct CheckedMulFastOp {
+  static const bool is_supported = false;
+  template <typename V>
+  static constexpr bool Do(T, U, V*) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<bool>();
+  }
+};
+
+template <typename T, typename U>
+struct ClampedAddFastOp {
+  static const bool is_supported = false;
+  template <typename V>
+  static constexpr V Do(T, U) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<V>();
+  }
+};
+
+template <typename T, typename U>
+struct ClampedSubFastOp {
+  static const bool is_supported = false;
+  template <typename V>
+  static constexpr V Do(T, U) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<V>();
+  }
+};
+
+template <typename T, typename U>
+struct ClampedMulFastOp {
+  static const bool is_supported = false;
+  template <typename V>
+  static constexpr V Do(T, U) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<V>();
+  }
+};
+
+template <typename T>
+struct ClampedNegFastOp {
+  static const bool is_supported = false;
+  static constexpr T Do(T) {
+    // Force a compile failure if instantiated.
+    return CheckOnFailure::template HandleFailure<T>();
+  }
+};
+#endif  // BASE_HAS_OPTIMIZED_SAFE_MATH
+#undef BASE_HAS_OPTIMIZED_SAFE_MATH
+
+// This is used for UnsignedAbs, where we need to support floating-point
+// template instantiations even though we don't actually support the operations.
+// However, there is no corresponding implementation of e.g. SafeUnsignedAbs,
+// so the float versions will not compile.
+template <typename Numeric>
+struct UnsignedOrFloatForSize;
+
+template <typename Numeric>
+  requires(std::integral<Numeric>)
+struct UnsignedOrFloatForSize<Numeric> {
+  using type = typename std::make_unsigned<Numeric>::type;
+};
+
+template <typename Numeric>
+  requires(std::floating_point<Numeric>)
+struct UnsignedOrFloatForSize<Numeric> {
+  using type = Numeric;
+};
+
+// Wrap the unary operations to allow SFINAE when instantiating integrals versus
+// floating points. These don't perform any overflow checking. Rather, they
+// exhibit well-defined overflow semantics and rely on the caller to detect
+// if an overflow occurred.
+
+template <typename T>
+  requires(std::integral<T>)
+constexpr T NegateWrapper(T value) {
+  using UnsignedT = typename std::make_unsigned<T>::type;
+  // This will compile to a NEG on Intel, and is normal negation on ARM.
+  return static_cast<T>(UnsignedT(0) - static_cast<UnsignedT>(value));
+}
+
+template <typename T>
+  requires(std::floating_point<T>)
+constexpr T NegateWrapper(T value) {
+  return -value;
+}
+
+template <typename T>
+  requires(std::integral<T>)
+constexpr typename std::make_unsigned<T>::type InvertWrapper(T value) {
+  return ~value;
+}
+
+template <typename T>
+  requires(std::integral<T>)
+constexpr T AbsWrapper(T value) {
+  return static_cast<T>(SafeUnsignedAbs(value));
+}
+
+template <typename T>
+  requires(std::floating_point<T>)
+constexpr T AbsWrapper(T value) {
+  return value < 0 ? -value : value;
+}
+
+template <template <typename, typename> class M, typename L, typename R>
+struct MathWrapper {
+  using math =
+      M<typename UnderlyingType<L>::type, typename UnderlyingType<R>::type>;
+  using type = typename math::result_type;
+};
+
+// The following macros are just boilerplate for the standard arithmetic
+// operator overloads and variadic function templates. A macro isn't the nicest
+// solution, but it beats rewriting these over and over again.
+#define BASE_NUMERIC_ARITHMETIC_VARIADIC(CLASS, CL_ABBR, OP_NAME)       \
+  template <typename L, typename R, typename... Args>                   \
+  constexpr auto CL_ABBR##OP_NAME(const L lhs, const R rhs,             \
+                                  const Args... args) {                 \
+    return CL_ABBR##MathOp<CLASS##OP_NAME##Op, L, R, Args...>(lhs, rhs, \
+                                                              args...); \
+  }
+
+#define BASE_NUMERIC_ARITHMETIC_OPERATORS(CLASS, CL_ABBR, OP_NAME, OP, CMP_OP) \
+  /* Binary arithmetic operator for all CLASS##Numeric operations. */          \
+  template <typename L, typename R,                                            \
+            typename = std::enable_if_t<Is##CLASS##Op<L, R>::value>>           \
+  constexpr CLASS##Numeric<                                                    \
+      typename MathWrapper<CLASS##OP_NAME##Op, L, R>::type>                    \
+  operator OP(const L lhs, const R rhs) {                                      \
+    return decltype(lhs OP rhs)::template MathOp<CLASS##OP_NAME##Op>(lhs,      \
+                                                                     rhs);     \
+  }                                                                            \
+  /* Assignment arithmetic operator implementation from CLASS##Numeric. */     \
+  template <typename L>                                                        \
+  template <typename R>                                                        \
+  constexpr CLASS##Numeric<L>& CLASS##Numeric<L>::operator CMP_OP(             \
+      const R rhs) {                                                           \
+    return MathOp<CLASS##OP_NAME##Op>(rhs);                                    \
+  }                                                                            \
+  /* Variadic arithmetic functions that return CLASS##Numeric. */              \
+  BASE_NUMERIC_ARITHMETIC_VARIADIC(CLASS, CL_ABBR, OP_NAME)
+
+}  // namespace internal
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_SAFE_MATH_SHARED_IMPL_H_

--- a/internal/base/numerics/wrapping_math.h
+++ b/internal/base/numerics/wrapping_math.h
@@ -1,0 +1,46 @@
+// Copyright 2023 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_WRAPPING_MATH_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_WRAPPING_MATH_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include <type_traits>
+
+namespace base {
+
+// Returns `a + b` with overflow defined to wrap around, i.e. modulo 2^N where N
+// is the bit width of `T`.
+template <typename T>
+inline constexpr T WrappingAdd(T a, T b) {
+  static_assert(std::is_integral_v<T>);
+  // Unsigned arithmetic wraps, so convert to the corresponding unsigned type.
+  // Note that, if `T` is smaller than `int`, e.g. `int16_t`, the values are
+  // promoted to `int`, which brings us back to undefined overflow. This is fine
+  // here because the sum of any two `int16_t`s fits in `int`, but `WrappingMul`
+  // will need a more complex implementation.
+  using Unsigned = std::make_unsigned_t<T>;
+  return static_cast<T>(static_cast<Unsigned>(a) + static_cast<Unsigned>(b));
+}
+
+// Returns `a - b` with overflow defined to wrap around, i.e. modulo 2^N where N
+// is the bit width of `T`.
+template <typename T>
+inline constexpr T WrappingSub(T a, T b) {
+  static_assert(std::is_integral_v<T>);
+  // Unsigned arithmetic wraps, so convert to the corresponding unsigned type.
+  // Note that, if `T` is smaller than `int`, e.g. `int16_t`, the values are
+  // promoted to `int`, which brings us back to undefined overflow. This is fine
+  // here because the difference of any two `int16_t`s fits in `int`, but
+  // `WrappingMul` will need a more complex implementation.
+  using Unsigned = std::make_unsigned_t<T>;
+  return static_cast<T>(static_cast<Unsigned>(a) - static_cast<Unsigned>(b));
+}
+
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_NUMERICS_WRAPPING_MATH_H_

--- a/internal/base/types/to_address.h
+++ b/internal/base/types/to_address.h
@@ -1,0 +1,44 @@
+// Copyright 2024 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BASE_TYPES_TO_ADDRESS_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BASE_TYPES_TO_ADDRESS_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include <memory>
+#include <type_traits>
+
+// SFINAE-compatible wrapper for `std::to_address()`.
+//
+// The standard does not require `std::to_address()` to be SFINAE-compatible
+// when code attempts instantiation with non-pointer-like types, and libstdc++'s
+// implementation hard errors. For the sake of templated code that wants simple,
+// unified handling, Chromium instead uses this wrapper, which provides that
+// guarantee. This allows code to use "`to_address()` would be valid here" as a
+// constraint to detect pointer-like types.
+namespace base {
+
+// Note that calling `std::to_address()` with a function pointer renders the
+// program ill-formed.
+template <typename T>
+  requires(!std::is_function_v<T>)
+constexpr T* to_address(T* p) noexcept {
+  return p;
+}
+
+// These constraints cover the cases where `std::to_address()`'s fancy pointer
+// overload is well-specified.
+template <typename P>
+  requires requires(const P& p) { std::pointer_traits<P>::to_address(p); } ||
+           requires(const P& p) { p.operator->(); }
+constexpr auto to_address(const P& p) noexcept {
+  return std::to_address(p);
+}
+
+}  // namespace base
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BASE_TYPES_TO_ADDRESS_H_

--- a/internal/build/BUILD
+++ b/internal/build/BUILD
@@ -1,0 +1,27 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])
+
+cc_library(
+    name = "build_chromium",
+    srcs = [
+    ],
+    hdrs = [
+        "build_config.h","buildflag.h",
+    ],
+    visibility = [
+        "//internal/base:__subpackages__",
+    ],
+)

--- a/internal/build/build_config.h
+++ b/internal/build/build_config.h
@@ -1,0 +1,409 @@
+// Copyright 2012 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file doesn't belong to any GN target by design for faster build and
+// less developer overhead.
+
+// This file adds build flags about the OS we're currently building on. They are
+// defined directly in this file instead of via a `buildflag_header` target in a
+// GN file for faster build. They are defined using the corresponding OS defines
+// (e.g. OS_WIN) which are also defined in this file (except for OS_CHROMEOS,
+// which is set by the build system). These defines are deprecated and should
+// NOT be used directly. For example:
+//    Please Use: #if BUILDFLAG(IS_WIN)
+//    Deprecated: #if defined(OS_WIN)
+//
+//  Operating System:
+//    IS_AIX / IS_ANDROID / IS_ASMJS / IS_CHROMEOS / IS_FREEBSD / IS_FUCHSIA /
+//    IS_IOS / IS_IOS_MACCATALYST / IS_IOS_VISION / IS_IOS_WATCH / IS_LINUX /
+//    IS_MAC / IS_NACL / IS_NETBSD / IS_OPENBSD / IS_QNX / IS_SOLARIS / IS_WIN
+//  Operating System family:
+//    IS_APPLE: MAC or IOS or IOS_MACCATALYST or IOS_VISION or IOS_WATCH
+//    IS_IOS: IOS or IOS_MACCATALYST or IOS_VISION or IOS_WATCH
+//    IS_BSD: FREEBSD or NETBSD or OPENBSD
+//    IS_POSIX: AIX or ANDROID or ASMJS or CHROMEOS or FREEBSD or IOS
+//              or IOS_MACCATALYST or IOS_VISION or IOS_WATCH or LINUX or MAC
+//              or NACL or NETBSD or OPENBSD or QNX or SOLARIS
+
+// This file also adds defines specific to the platform, architecture etc.
+//
+//  Platform:
+//    IS_OZONE
+//
+//  Compiler:
+//    COMPILER_MSVC / COMPILER_GCC
+//
+//  Processor:
+//    ARCH_CPU_ARM64 / ARCH_CPU_ARMEL / ARCH_CPU_LOONGARCH32 /
+//    ARCH_CPU_LOONGARCH64 / ARCH_CPU_MIPS / ARCH_CPU_MIPS64 /
+//    ARCH_CPU_MIPS64EL / ARCH_CPU_MIPSEL / ARCH_CPU_PPC64 / ARCH_CPU_S390 /
+//    ARCH_CPU_S390X / ARCH_CPU_X86 / ARCH_CPU_X86_64 / ARCH_CPU_RISCV64
+//  Processor family:
+//    ARCH_CPU_ARM_FAMILY: ARMEL or ARM64
+//    ARCH_CPU_LOONGARCH_FAMILY: LOONGARCH32 or LOONGARCH64
+//    ARCH_CPU_MIPS_FAMILY: MIPS64EL or MIPSEL or MIPS64 or MIPS
+//    ARCH_CPU_PPC64_FAMILY: PPC64
+//    ARCH_CPU_S390_FAMILY: S390 or S390X
+//    ARCH_CPU_X86_FAMILY: X86 or X86_64
+//    ARCH_CPU_RISCV_FAMILY: Riscv64
+//  Processor features:
+//    ARCH_CPU_31_BITS / ARCH_CPU_32_BITS / ARCH_CPU_64_BITS
+//    ARCH_CPU_BIG_ENDIAN / ARCH_CPU_LITTLE_ENDIAN
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BUILD_BUILD_CONFIG_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BUILD_BUILD_CONFIG_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+#include "internal/build/buildflag.h"  // IWYU pragma: export
+
+// A set of macros to use for platform detection.
+#if defined(__native_client__)
+// __native_client__ must be first, so that other OS_ defines are not set.
+#define OS_NACL 1
+#elif defined(ANDROID)
+#define OS_ANDROID 1
+#elif defined(__APPLE__)
+// Only include TargetConditionals after testing ANDROID as some Android builds
+// on the Mac have this header available and it's not needed unless the target
+// is really an Apple platform.
+#include <TargetConditionals.h>
+#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+#define OS_IOS 1
+// Catalyst is the technology that allows running iOS apps on macOS. These
+// builds are both OS_IOS and OS_IOS_MACCATALYST.
+#if defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST
+#define OS_IOS_MACCATALYST
+#endif  // defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST
+#if defined(TARGET_OS_VISION) && TARGET_OS_VISION
+#define OS_IOS_VISION 1
+#endif  // defined(TARGET_OS_VISION) && TARGET_OS_VISION
+#if defined(TARGET_OS_WATCH) && TARGET_OS_WATCH
+#define OS_IOS_WATCH 1
+#endif  // defined(TARGET_OS_WATCH) && TARGET_OS_WATCH
+#else
+#define OS_MAC 1
+#endif  // defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+#elif defined(__linux__)
+#if !defined(OS_CHROMEOS)
+// Do not define OS_LINUX on Chrome OS build.
+// The OS_CHROMEOS macro is defined in GN.
+#define OS_LINUX 1
+#endif  // !defined(OS_CHROMEOS)
+// Include a system header to pull in features.h for glibc/uclibc macros.
+#include <assert.h>
+#if defined(__GLIBC__) && !defined(__UCLIBC__)
+// We really are using glibc, not uClibc pretending to be glibc.
+#define LIBC_GLIBC 1
+#endif
+#elif defined(_WIN32)
+#define OS_WIN 1
+#elif defined(__Fuchsia__)
+#define OS_FUCHSIA 1
+#elif defined(__FreeBSD__)
+#define OS_FREEBSD 1
+#elif defined(__NetBSD__)
+#define OS_NETBSD 1
+#elif defined(__OpenBSD__)
+#define OS_OPENBSD 1
+#elif defined(__sun)
+#define OS_SOLARIS 1
+#elif defined(__QNXNTO__)
+#define OS_QNX 1
+#elif defined(_AIX)
+#define OS_AIX 1
+#elif defined(__asmjs__) || defined(__wasm__)
+#define OS_ASMJS 1
+#elif defined(__MVS__)
+#define OS_ZOS 1
+#else
+#error Please add support for your platform in build/build_config.h
+#endif
+// NOTE: Adding a new port? Please follow
+// https://chromium.googlesource.com/chromium/src/+/main/docs/new_port_policy.md
+
+#if defined(OS_MAC) || defined(OS_IOS)
+#define OS_APPLE 1
+#endif
+
+// For access to standard BSD features, use OS_BSD instead of a
+// more specific macro.
+#if defined(OS_FREEBSD) || defined(OS_NETBSD) || defined(OS_OPENBSD)
+#define OS_BSD 1
+#endif
+
+// For access to standard POSIXish features, use OS_POSIX instead of a
+// more specific macro.
+#if defined(OS_AIX) || defined(OS_ANDROID) || defined(OS_ASMJS) ||  \
+    defined(OS_FREEBSD) || defined(OS_IOS) || defined(OS_LINUX) ||  \
+    defined(OS_CHROMEOS) || defined(OS_MAC) || defined(OS_NACL) ||  \
+    defined(OS_NETBSD) || defined(OS_OPENBSD) || defined(OS_QNX) || \
+    defined(OS_SOLARIS) || defined(OS_ZOS)
+#define OS_POSIX 1
+#endif
+
+// OS build flags
+#if defined(OS_AIX)
+#define BUILDFLAG_INTERNAL_IS_AIX() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_AIX() (0)
+#endif
+
+#if defined(OS_ANDROID)
+#define BUILDFLAG_INTERNAL_IS_ANDROID() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_ANDROID() (0)
+#endif
+
+#if defined(OS_APPLE)
+#define BUILDFLAG_INTERNAL_IS_APPLE() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_APPLE() (0)
+#endif
+
+#if defined(OS_ASMJS)
+#define BUILDFLAG_INTERNAL_IS_ASMJS() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_ASMJS() (0)
+#endif
+
+#if defined(OS_BSD)
+#define BUILDFLAG_INTERNAL_IS_BSD() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_BSD() (0)
+#endif
+
+#if defined(OS_CHROMEOS)
+#define BUILDFLAG_INTERNAL_IS_CHROMEOS() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_CHROMEOS() (0)
+#endif
+
+#if defined(OS_FREEBSD)
+#define BUILDFLAG_INTERNAL_IS_FREEBSD() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_FREEBSD() (0)
+#endif
+
+#if defined(OS_FUCHSIA)
+#define BUILDFLAG_INTERNAL_IS_FUCHSIA() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_FUCHSIA() (0)
+#endif
+
+#if defined(OS_IOS)
+#define BUILDFLAG_INTERNAL_IS_IOS() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_IOS() (0)
+#endif
+
+#if defined(OS_IOS_MACCATALYST)
+#define BUILDFLAG_INTERNAL_IS_IOS_MACCATALYST() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_IOS_MACCATALYST() (0)
+#endif
+
+#if defined(OS_IOS_VISION)
+#define BUILDFLAG_INTERNAL_IS_IOS_VISION() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_IOS_VISION() (0)
+#endif
+
+#if defined(OS_IOS_WATCH)
+#define BUILDFLAG_INTERNAL_IS_IOS_WATCH() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_IOS_WATCH() (0)
+#endif
+
+#if defined(OS_LINUX)
+#define BUILDFLAG_INTERNAL_IS_LINUX() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_LINUX() (0)
+#endif
+
+#if defined(OS_MAC)
+#define BUILDFLAG_INTERNAL_IS_MAC() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_MAC() (0)
+#endif
+
+#if defined(OS_NACL)
+#define BUILDFLAG_INTERNAL_IS_NACL() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_NACL() (0)
+#endif
+
+#if defined(OS_NETBSD)
+#define BUILDFLAG_INTERNAL_IS_NETBSD() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_NETBSD() (0)
+#endif
+
+#if defined(OS_OPENBSD)
+#define BUILDFLAG_INTERNAL_IS_OPENBSD() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_OPENBSD() (0)
+#endif
+
+#if defined(OS_POSIX)
+#define BUILDFLAG_INTERNAL_IS_POSIX() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_POSIX() (0)
+#endif
+
+#if defined(OS_QNX)
+#define BUILDFLAG_INTERNAL_IS_QNX() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_QNX() (0)
+#endif
+
+#if defined(OS_SOLARIS)
+#define BUILDFLAG_INTERNAL_IS_SOLARIS() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_SOLARIS() (0)
+#endif
+
+#if defined(OS_WIN)
+#define BUILDFLAG_INTERNAL_IS_WIN() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_WIN() (0)
+#endif
+
+#if defined(USE_OZONE)
+#define BUILDFLAG_INTERNAL_IS_OZONE() (1)
+#else
+#define BUILDFLAG_INTERNAL_IS_OZONE() (0)
+#endif
+
+// Compiler detection. Note: clang masquerades as GCC on POSIX and as MSVC on
+// Windows.
+#if defined(__GNUC__)
+#define COMPILER_GCC 1
+#elif defined(_MSC_VER)
+#define COMPILER_MSVC 1
+#else
+#error Please add support for your compiler in build/build_config.h
+#endif
+
+// Processor architecture detection.  For more info on what's defined, see:
+//   http://msdn.microsoft.com/en-us/library/b0084kay.aspx
+//   http://www.agner.org/optimize/calling_conventions.pdf
+//   or with gcc, run: "echo | gcc -E -dM -"
+#if defined(_M_X64) || defined(__x86_64__)
+#define ARCH_CPU_X86_FAMILY 1
+#define ARCH_CPU_X86_64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(_M_IX86) || defined(__i386__)
+#define ARCH_CPU_X86_FAMILY 1
+#define ARCH_CPU_X86 1
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__s390x__)
+#define ARCH_CPU_S390_FAMILY 1
+#define ARCH_CPU_S390X 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_BIG_ENDIAN 1
+#elif defined(__s390__)
+#define ARCH_CPU_S390_FAMILY 1
+#define ARCH_CPU_S390 1
+#define ARCH_CPU_31_BITS 1
+#define ARCH_CPU_BIG_ENDIAN 1
+#elif (defined(__PPC64__) || defined(__PPC__)) && defined(__BIG_ENDIAN__)
+#define ARCH_CPU_PPC64_FAMILY 1
+#define ARCH_CPU_PPC64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_BIG_ENDIAN 1
+#elif defined(__PPC64__)
+#define ARCH_CPU_PPC64_FAMILY 1
+#define ARCH_CPU_PPC64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__ARMEL__)
+#define ARCH_CPU_ARM_FAMILY 1
+#define ARCH_CPU_ARMEL 1
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#define ARCH_CPU_ARM_FAMILY 1
+#define ARCH_CPU_ARM64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__pnacl__) || defined(__asmjs__) || defined(__wasm__)
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__MIPSEL__)
+#if defined(__LP64__)
+#define ARCH_CPU_MIPS_FAMILY 1
+#define ARCH_CPU_MIPS64EL 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#else
+#define ARCH_CPU_MIPS_FAMILY 1
+#define ARCH_CPU_MIPSEL 1
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#endif
+#elif defined(__MIPSEB__)
+#if defined(__LP64__)
+#define ARCH_CPU_MIPS_FAMILY 1
+#define ARCH_CPU_MIPS64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_BIG_ENDIAN 1
+#else
+#define ARCH_CPU_MIPS_FAMILY 1
+#define ARCH_CPU_MIPS 1
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_BIG_ENDIAN 1
+#endif
+#elif defined(__loongarch__)
+#define ARCH_CPU_LOONGARCH_FAMILY 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#if __loongarch_grlen == 64
+#define ARCH_CPU_LOONGARCH64 1
+#define ARCH_CPU_64_BITS 1
+#else
+#define ARCH_CPU_LOONGARCH32 1
+#define ARCH_CPU_32_BITS 1
+#endif
+#elif defined(__riscv) && (__riscv_xlen == 64)
+#define ARCH_CPU_RISCV_FAMILY 1
+#define ARCH_CPU_RISCV64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#else
+#error Please add support for your architecture in build/build_config.h
+#endif
+
+// Type detection for wchar_t.
+#if defined(OS_WIN)
+#define WCHAR_T_IS_16_BIT
+#elif defined(OS_FUCHSIA)
+#define WCHAR_T_IS_32_BIT
+#elif defined(OS_POSIX) && defined(COMPILER_GCC) && defined(__WCHAR_MAX__) && \
+    (__WCHAR_MAX__ == 0x7fffffff || __WCHAR_MAX__ == 0xffffffff)
+#define WCHAR_T_IS_32_BIT
+#elif defined(OS_POSIX) && defined(COMPILER_GCC) && defined(__WCHAR_MAX__) && \
+    (__WCHAR_MAX__ == 0x7fff || __WCHAR_MAX__ == 0xffff)
+// On Posix, we'll detect short wchar_t, but projects aren't guaranteed to
+// compile in this mode (in particular, Chrome doesn't). This is intended for
+// other projects using base who manage their own dependencies and make sure
+// short wchar works for them.
+#define WCHAR_T_IS_16_BIT
+#else
+#error Please add support for your compiler in build/build_config.h
+#endif
+
+#if defined(OS_ANDROID)
+// The compiler thinks std::string::const_iterator and "const char*" are
+// equivalent types.
+#define STD_STRING_ITERATOR_IS_CHAR_POINTER
+// The compiler thinks std::u16string::const_iterator and "char16*" are
+// equivalent types.
+#define BASE_STRING16_ITERATOR_IS_CHAR16_POINTER
+#endif
+
+#endif  // BUILD_BUILD_CONFIG_H_

--- a/internal/build/buildflag.h
+++ b/internal/build/buildflag.h
@@ -1,0 +1,51 @@
+// Copyright 2015 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_BUILD_BUILDFLAG_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_BUILD_BUILDFLAG_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
+
+// These macros un-mangle the names of the build flags in a way that looks
+// natural, and gives errors if the flag is not defined. Normally in the
+// preprocessor it's easy to make mistakes that interpret "you haven't done
+// the setup to know what the flag is" as "flag is off". Normally you would
+// include the generated header rather than include this file directly.
+//
+// This is for use with generated headers. See build/buildflag_header.gni.
+
+// This dance of two macros does a concatenation of two preprocessor args using
+// ## doubly indirectly because using ## directly prevents macros in that
+// parameter from being expanded.
+#define BUILDFLAG_CAT_INDIRECT(a, b) a ## b
+#define BUILDFLAG_CAT(a, b) BUILDFLAG_CAT_INDIRECT(a, b)
+
+// Accessor for build flags.
+//
+// To test for a value, if the build file specifies:
+//
+//   ENABLE_FOO=true
+//
+// Then you would check at build-time in source code with:
+//
+//   #include "foo_flags.h"  // The header the build file specified.
+//
+//   #if BUILDFLAG(ENABLE_FOO)
+//     ...
+//   #endif
+//
+// There will no #define called ENABLE_FOO so if you accidentally test for
+// whether that is defined, it will always be negative. You can also use
+// the value in expressions:
+//
+//   const char kSpamServerName[] = BUILDFLAG(SPAM_SERVER_NAME);
+//
+// Because the flag is accessed as a preprocessor macro with (), an error
+// will be thrown if the proper header defining the internal flag value has
+// not been included.
+#define BUILDFLAG(flag) (BUILDFLAG_CAT(BUILDFLAG_INTERNAL_, flag)())
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_BUILD_BUILDFLAG_H_

--- a/internal/crypto/ed25519.cc
+++ b/internal/crypto/ed25519.cc
@@ -22,9 +22,16 @@
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
-#include "internal/crypto_cros/random.h"
 #include <openssl/base.h>
 #include <openssl/evp.h>
+
+#ifdef NEARBY_CHROMIUM
+#include "base/containers/span.h"
+#include "crypto/random.h"
+#else
+#include "internal/base/containers/span.h"
+#include "internal/crypto_cros/random.h"
+#endif
 
 namespace crypto {
 
@@ -98,9 +105,8 @@ absl::StatusOr<Ed25519KeyPair> Ed25519Signer::CreateNewKeyPair(
 
 absl::StatusOr<Ed25519KeyPair> Ed25519Signer::CreateNewKeyPair() {
   uint8_t key_seed[kEd25519KeySeedSize] = {0};
-  RandBytes(key_seed, kEd25519KeySeedSize);
-  return CreateNewKeyPair(
-      std::string(reinterpret_cast<char *>(key_seed), kEd25519KeySeedSize));
+  RandBytes(key_seed);
+  return CreateNewKeyPair(std::string(base::as_string_view(key_seed)));
 }
 
 Ed25519Signer::Ed25519Signer(CryptoKeyUniquePtr private_key) {

--- a/internal/crypto_cros/BUILD
+++ b/internal/crypto_cros/BUILD
@@ -39,7 +39,6 @@ cc_library(
         "hmac.cc",
         "nearby_base.cc",
         "openssl_util.cc",
-        "random.cc",
         "rsa_private_key.cc",
         "secure_hash.cc",
         "secure_util.cc",
@@ -58,7 +57,6 @@ cc_library(
         "hmac.h",
         "nearby_base.h",
         "openssl_util.h",
-        "random.h",
         "rsa_private_key.h",
         "secure_hash.h",
         "secure_util.h",
@@ -71,6 +69,8 @@ cc_library(
         "-Ithird_party",
     ],
     deps = [
+        "//internal/base:base_chromium",
+        ":crypto_chromium",
         "@boringssl//:crypto",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/log",
@@ -81,6 +81,25 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_library(
+    name = "crypto_chromium",
+    srcs = [
+        "random.cc",
+    ],
+    hdrs = [
+        "crypto_chromium_export.h",
+        "random.h",
+    ],
+    copts = [
+        "-DCRYPTO_CHROMIUM_IMPLEMENTATION",
+        "-Ithird_party",
+    ],
+    deps = [
+        "//internal/base:base_chromium",
+        "@boringssl//:crypto",
     ],
 )
 

--- a/internal/crypto_cros/crypto_chromium_export.h
+++ b/internal/crypto_cros/crypto_chromium_export.h
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_CRYPTO_CRYPTO_CHROMIUM_EXPORT_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_CRYPTO_CRYPTO_CHROMIUM_EXPORT_H_
+
+// Defines CRYPTO_CHROMIUM_EXPORT so that functionality implemented by the crypto module
+// can be exported to consumers.
+
+#if defined(COMPONENT_BUILD)
+#if defined(WIN32)
+
+#if defined(CRYPTO_IMPLEMENTATION)
+#define CRYPTO_CHROMIUM_EXPORT __declspec(dllexport)
+#else
+#define CRYPTO_CHROMIUM_EXPORT __declspec(dllimport)
+#endif  // defined(CRYPTO_IMPLEMENTATION)
+
+#else  // defined(WIN32)
+#if defined(CRYPTO_IMPLEMENTATION)
+#define CRYPTO_CHROMIUM_EXPORT __attribute__((visibility("default")))
+#else
+#define CRYPTO_CHROMIUM_EXPORT
+#endif
+#endif
+
+#else  // defined(COMPONENT_BUILD)
+#define CRYPTO_CHROMIUM_EXPORT
+#endif
+
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_CRYPTO_CRYPTO_CHROMIUM_EXPORT_H_

--- a/internal/crypto_cros/random.h
+++ b/internal/crypto_cros/random.h
@@ -16,27 +16,26 @@
 // This file needs to be in sync with:
 // https://source.chromium.org/chromium/chromium/src/+/main:crypto/random.h
 
-#ifndef THIRD_PARTY_NEARBY_INTERNAL_CRYPTO_RANDOM_H_
-#define THIRD_PARTY_NEARBY_INTERNAL_CRYPTO_RANDOM_H_
+#ifndef THIRD_PARTY_NEARBY_INTERNAL_CRYPTO_CHROMIUM_H_
+#define THIRD_PARTY_NEARBY_INTERNAL_CRYPTO_CHROMIUM_H_
+
+#ifdef NEARBY_CHROMIUM
+#error "Use chromium headers when NEARBY_CHROMIUM is defined."
+#endif
 
 #include <stddef.h>
 
 #include <cstdint>
 #include <string>
 
-#include "absl/types/span.h"
-#include "internal/crypto_cros/crypto_export.h"
+#include "internal/base/containers/span.h"
+#include "internal/crypto_cros/crypto_chromium_export.h"
 
 namespace crypto {
 
-// Fills the given buffer with |length| random bytes of cryptographically
-// secure random numbers.
-// |length| must be positive.
-CRYPTO_EXPORT void RandBytes(void *bytes, size_t length);
-
-// Fills |bytes| with cryptographically-secure random bits.
-CRYPTO_EXPORT void RandBytes(absl::Span<uint8_t> bytes);
+// Fills `bytes` with cryptographically-secure random bits.
+CRYPTO_CHROMIUM_EXPORT void RandBytes(base::span<uint8_t> bytes);
 
 }  // namespace crypto
 
-#endif  // THIRD_PARTY_NEARBY_INTERNAL_CRYPTO_RANDOM_H_
+#endif  // THIRD_PARTY_NEARBY_INTERNAL_CRYPTO_CHROMIUM_H_

--- a/internal/crypto_cros/random_unittest.cc
+++ b/internal/crypto_cros/random_unittest.cc
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "gtest/gtest.h"
+#include "internal/base/containers/span.h"
 #include "internal/crypto_cros/nearby_base.h"
 #include "internal/platform/implementation/crypto.h"
 
@@ -40,17 +41,7 @@ bool IsTrivial(const std::string& bytes) {
 
 TEST(RandBytes, RandBytes) {
   std::string bytes(16, '\0');
-  RandBytes(nearbybase::WriteInto(&bytes, bytes.size()), bytes.size());
-  EXPECT_TRUE(!IsTrivial(bytes));
-}
-
-TEST(RandBytes, RandomString) {
-  constexpr size_t kSize = 30;
-
-  std::string bytes(kSize, 0);
-  RandBytes(const_cast<std::string::value_type*>(bytes.data()), bytes.size());
-
-  EXPECT_EQ(bytes.size(), kSize);
+  RandBytes(base::as_writable_byte_span(bytes));
   EXPECT_TRUE(!IsTrivial(bytes));
 }
 

--- a/internal/platform/implementation/crypto.h
+++ b/internal/platform/implementation/crypto.h
@@ -17,8 +17,10 @@
 
 #include "absl/strings/string_view.h"
 #ifdef NEARBY_CHROMIUM
+#include "base/containers/span.h"
 #include "crypto/random.h"
 #else
+#include "internal/base/containers/span.h"
 #include "internal/crypto_cros/random.h"
 #endif
 #include "internal/platform/byte_array.h"
@@ -41,7 +43,7 @@ class Crypto {
 template <typename T>
 T RandData() {
   T data;
-  ::crypto::RandBytes(&data, sizeof(data));
+  ::crypto::RandBytes(base::byte_span_from_ref(data));
   return data;
 }
 

--- a/presence/implementation/base_broadcast_request.cc
+++ b/presence/implementation/base_broadcast_request.cc
@@ -74,8 +74,7 @@ BasePresenceRequestBuilder::operator BaseBroadcastRequest() const {
       .action = action_};
 
   std::string bytes(kSaltSize, 0);
-  crypto::RandBytes(const_cast<std::string::value_type*>(bytes.data()),
-                    bytes.size());
+  crypto::RandBytes(base::as_writable_byte_span(bytes));
 
   BaseBroadcastRequest broadcast_request{
       .variant = presence,

--- a/presence/implementation/credential_manager_impl.cc
+++ b/presence/implementation/credential_manager_impl.cc
@@ -187,8 +187,7 @@ CredentialManagerImpl::CreateLocalCredential(
 
   // Creates an AES key to encrypt the whole broadcast.
   std::string secret_key(kAuthenticityKeyByteSize, 0);
-  crypto::RandBytes(const_cast<std::string::value_type*>(secret_key.data()),
-                    secret_key.size());
+  crypto::RandBytes(base::as_writable_byte_span(secret_key));
   private_credential.set_key_seed(secret_key);
 
   // Uses SHA-256 algorithm to generate the credential ID from the
@@ -211,8 +210,7 @@ CredentialManagerImpl::CreateLocalCredential(
       std::string(private_key.begin(), private_key.end()));
   // Create an AES key to encrypt the device identity metadata.
   std::string metadata_key(kBaseMetadataSize, 0);
-  crypto::RandBytes(const_cast<std::string::value_type*>(metadata_key.data()),
-                    metadata_key.size());
+  crypto::RandBytes(base::as_writable_byte_span(metadata_key));
   private_credential.set_metadata_encryption_key_v0(metadata_key);
 
   // Generate the public credential

--- a/sharing/attachment.cc
+++ b/sharing/attachment.cc
@@ -16,7 +16,13 @@
 
 #include <stdint.h>
 
+#if NEARBY_CHROMIUM
+#include "base/containers/span.h"
+#include "crypto/random.h"
+#else
+#include "internal/base/containers/span.h"
 #include "internal/crypto_cros/random.h"
+#endif
 
 namespace nearby {
 namespace sharing {
@@ -24,7 +30,7 @@ namespace {
 
 int64_t CreateRandomId() {
   int64_t id;
-  crypto::RandBytes(&id, sizeof(id));
+  crypto::RandBytes(base::byte_span_from_ref(id));
   return id;
 }
 

--- a/sharing/certificates/common.cc
+++ b/sharing/certificates/common.cc
@@ -77,7 +77,7 @@ std::vector<uint8_t> ComputeAuthenticationTokenHash(
 
 std::vector<uint8_t> GenerateRandomBytes(size_t num_bytes) {
   std::vector<uint8_t> bytes(num_bytes);
-  crypto::RandBytes(absl::Span<uint8_t>(bytes));
+  crypto::RandBytes(bytes);
   return bytes;
 }
 

--- a/sharing/nearby_connections_types.h
+++ b/sharing/nearby_connections_types.h
@@ -472,7 +472,7 @@ struct Payload {
 
   int64_t GenerateId() {
     int64_t id;
-    crypto::RandBytes(&id, sizeof(id));
+    crypto::RandBytes(base::byte_span_from_ref(id));
     return id;
   }
 };


### PR DESCRIPTION
The pointer-based overload is going away in Chromium base: https://chromium-review.googlesource.com/c/chromium/src/+/5514816

Add `base/containers/span.h` to the Chromium build shims, and use it from
`internal/crypto_cros/random.h`. This makes the signature match and also provides
all the base span helpers that are needed to work with spans nicely.

Then we use those helpers to convert calls to the span-based `RandBytes()`.

There is previously some confusion in the Chromium shims as they have the same names
and namespaces as Chromium but not always the same signatures. And the shims are
sometimes included even in a Chromium build, which produces ODR violations. To resolve
this we:
- Split random.h and random.cc into a separate `random_chromuim` build target.
- Introduce new base headers from chromium into a `base_chromium` build target.
- Introduce new build headers from chromium into a `build_chromium` build target.
- In every chromium shim header add an `#error` if included inside the chromium build,
  which is when `NEARBY_CHROMIUM` is defined.

Then, we fix a few include sites of random.h to only include the shim when not in the
Chromium build. As we find the `#error` hit in the Chromium build now.