### PR TITLE
Remove validation steps related to fastpair rust

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -61,20 +61,4 @@ jobs:
         submodules: recursive
     - name: Build FPP
       run:  cargo build --manifest-path presence/fpp/fpp/Cargo.toml
-    - name: Build Bluetooth Module
-      run:  cargo test --manifest-path fastpair/rust/bluetooth/Cargo.toml
-    - name: Build Fast Pair
-      run:  cargo test --manifest-path fastpair/rust/demo/rust/Cargo.toml
-
-  build-rust-windows:
-    name: Build Rust on Windows
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-    - name: Build Bluetooth Module
-      run:  cargo test --manifest-path fastpair/rust/bluetooth/Cargo.toml
-    - name: Build Fast Pair
-      run:  cargo test --manifest-path fastpair/rust/demo/rust/Cargo.toml
   


### PR DESCRIPTION
## Summary
This project was removed as part of deprecating OSS fastpair.

## How did you test this change?
CI
