### PR TITLE
Nearby for Windows

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,3 +1,5 @@
+module(name = "nearby", version = "1.0.0")
+
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_apple", version = "4.3.3")
 bazel_dep(name = "rules_cc", version = "0.2.16")
@@ -57,7 +59,6 @@ cc_library(
     name = "libmurmur3",
     srcs = ["src/MurmurHash3.cpp"],
     hdrs = ["src/MurmurHash3.h"],
-    copts = ["-Wno-implicit-fallthrough"],
     licenses = ["unencumbered"],  # MurmurHash is explicity public-domain
 )""",
     strip_prefix = "smhasher-master",

--- a/connections/implementation/wifi_hotspot_bwu_handler.cc
+++ b/connections/implementation/wifi_hotspot_bwu_handler.cc
@@ -20,6 +20,10 @@
 #include <sys/socket.h>
 #endif
 
+#if defined(_WIN32)
+#include <winsock2.h>
+#endif
+
 #include <cstdint>
 #include <cstring>
 #include <memory>


### PR DESCRIPTION
## Summary

The current version of Nearby cannot build the '//connection:core' target on Windows due to incompatible flags and missing headers.

* '-Wno-implicit-fallthrough' isn't supported by MSVC.
* 'wifi_hotspot_bwu_handler.cc' drops errors for 'inet_addr(...)' and its macros because it is missing the '<winsock2.h>' header.

Additionally, add 'module(...)' to 'MODULE.bazel' to enable the use of 'local_path_override(...)' or use 'nearby' as a local dependency.

## How did you test this change?

Some original source files use modern C++20 features such as <=> operator instead of C++17:
`bazel build //connections:core --cxxopt=/std:c++20 --host_cxxopt=/std:c++20`