### PR TITLE
Fix SwiftPM manifest trailing comma

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -103,7 +103,7 @@ let package = Package(
       publicHeadersPath: ".",
       cSettings: [
         .headerSearchPath("./"),
-      ],
+      ]
     ),
     .target(
       name: "protobuf",


### PR DESCRIPTION
## Summary
Removes a trailing comma after the final `cSettings` argument in the `protobuf-utf8` target. With SwiftPM this currently stops manifest evaluation before the package can be described or built.

## Reproduction
On current `main` (`24c6dd901536f385c8085ef168e37b05af7a01f7`), `swift package describe` fails with:

```text
Package.swift:108:5: error: unexpected ',' separator
```

## Verification
With this patch and submodules initialized at the pinned commits:

```sh
env HOME=/private/tmp/tpc-swift-home \
  CLANG_MODULE_CACHE_PATH=/private/tmp/tpc-clang-module-cache \
  swift package describe

env HOME=/private/tmp/tpc-swift-home \
  CLANG_MODULE_CACHE_PATH=/private/tmp/tpc-clang-module-cache \
  swift build --product NearbyConnections

env HOME=/private/tmp/tpc-swift-home \
  CLANG_MODULE_CACHE_PATH=/private/tmp/tpc-clang-module-cache \
  swift test --filter BuildTests
```

Result: package describe passes, `NearbyConnections` builds, and `BuildTests` pass.
