### PR TITLE
ci: add workflow-level contents: read to validate.yaml

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -16,6 +16,9 @@ name: Validate
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: true
 


### PR DESCRIPTION
Tiny hardening. The three jobs in `validate.yaml` (`build-swift`, `test-swift`, `build-linux`) check out the repo and run swift build / swift test / bazel build. They don't push, comment, or call any GitHub write endpoint — `contents: read` is the actual minimum scope.

It's the only workflow in `.github/workflows/` without a permissions declaration. YAML parses.