### PR TITLE
Fix undefined variable reference in Android sharing README sample

### DIFF
--- a/sharing/android/README.md
+++ b/sharing/android/README.md
@@ -13,7 +13,7 @@ val shareIntent = Intent("com.google.android.gms.SHARE_NEARBY")
         .putExtra(Intent.EXTRA_TEXT, "Hello Nearby");
 
 val packageManager = context.packageManager;
-val activities = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+val activities = packageManager.queryIntentActivities(shareIntent, PackageManager.MATCH_DEFAULT_ONLY);
 // If the activities list is not empty, the intent can be handled and the intent can be called!
 ```
 


### PR DESCRIPTION
## Problem
The sample Kotlin snippet under "Checking if Quick Share (Google) is supported on your device" in `sharing/android/README.md` builds a `shareIntent`, but then calls `packageManager.queryIntentActivities(intent, ...)` with an undefined `intent` variable. As written, the snippet does not compile and misleads anyone copying it.

## Change
Rename the argument to `shareIntent` so the query checks the intent that was actually constructed:
```kotlin
val activities = packageManager.queryIntentActivities(shareIntent, PackageManager.MATCH_DEFAULT_ONLY)
```

## Why this is safe
Documentation-only change in a single line of an example code block. No production code, build configuration, or behavior is affected.

## Verification
The surrounding snippet now uses a single, consistently named variable (`shareIntent`) from declaration through the `queryIntentActivities` call. Verified against the file content at `sharing/android/README.md` on the default branch.