### PR TITLE
Complete the pending characteristic write when the BLE peer disconnects remotely

### DIFF
--- a/internal/platform/implementation/apple/Mediums/BLE/Sockets/Source/Central/GNSCentralPeerManager.m
+++ b/internal/platform/implementation/apple/Mediums/BLE/Sockets/Source/Central/GNSCentralPeerManager.m
@@ -674,7 +674,13 @@ static NSString *PeripheralStateString(CBPeripheralState state) {
   __weak __typeof__(self) weakSelf = self;
   dispatch_block_t dataWriteTimeoutBlock = dispatch_block_create(0, ^{
     __typeof__(self) strongSelf = weakSelf;
-    if (!strongSelf || !socket.isConnected) return;
+    if (!strongSelf) return;
+    if (!socket.isConnected) {
+      // The socket died with this write installed (cross-queue window):
+      // complete it with an error instead of leaving it orphaned forever.
+      [strongSelf callDataWriteCompletionWithError:GNSErrorWithCode(GNSErrorNoConnection)];
+      return;
+    }
     GNCLoggerInfo(@"Characteristic data write timed out");
     [strongSelf callDataWriteCompletionWithError:GNSErrorWithCode(GNSErrorConnectionTimedOut)];
   });

--- a/internal/platform/implementation/apple/Mediums/BLE/Sockets/Source/Central/GNSCentralPeerManager.m
+++ b/internal/platform/implementation/apple/Mediums/BLE/Sockets/Source/Central/GNSCentralPeerManager.m
@@ -322,6 +322,10 @@ static NSString *PeripheralStateString(CBPeripheralState state) {
   NSAssert(_cbPeripheral.delegate == self, @"Self = %@ should be the delegate of %@", self,
            _cbPeripheral);
 
+  // If there is a pending characteristic write, call the completion.
+  // Mirrors disconnectingWithError:, which already purges on the local path.
+  [self callDataWriteCompletionWithError:GNSErrorWithCode(GNSErrorLostConnection)];
+
   // Clean-up this peer manager.
   [_centralManager centralPeerManagerDidDisconnect:self];
   GNSSocket *currentSocket = _socket;

--- a/internal/platform/implementation/apple/Mediums/BLE/Sockets/Tests/Central/GNSCentralPeerManagerTest.m
+++ b/internal/platform/implementation/apple/Mediums/BLE/Sockets/Tests/Central/GNSCentralPeerManagerTest.m
@@ -1063,4 +1063,64 @@ static FakeTimer *gTimer;
   XCTAssertEqual(writeError.code, GNSErrorLostConnection);
 }
 
+
+#pragma mark - Data write timeout backstop
+
+// Waits past the 0.5 s deadline that -sendData:socket:completion: gives a write, so the timeout
+// block has run. The deadline uses -dispatch_after and cannot be faked.
+- (void)waitForDataWriteTimeout {
+  XCTestExpectation *elapsed = [self expectationWithDescription:@"data write timeout elapsed"];
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.8 * NSEC_PER_SEC)),
+                 dispatch_get_main_queue(), ^{
+                   [elapsed fulfill];
+                 });
+  [self waitForExpectationsWithTimeout:kDefaultTimeout * 2 handler:nil];
+}
+
+// A write can be installed while the socket is already gone, because the caller runs on another
+// queue and does not observe the disconnection until later. The timeout block used to return
+// without completing that write, leaving it orphaned with no deadline left to catch it.
+- (void)testDataWriteTimeoutCompletesWriteInstalledAfterDisconnection {
+  [self simulateConnectedSocketWithPairingChar:NO];
+  GNSSocket *socket = _socket;
+
+  _peripheral.state = CBPeripheralStateDisconnected;
+  [_centralPeerManager bleDisconnectedWithError:nil];
+  [self drainMainQueue];
+  XCTAssertFalse(socket.isConnected);
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"write completion"];
+  __block NSError *writeError = nil;
+  [(id<GNSSocketOwner>)_centralPeerManager sendData:[@"data" dataUsingEncoding:NSUTF8StringEncoding]
+                                             socket:socket
+                                         completion:^(NSError *error) {
+                                           writeError = error;
+                                           [expectation fulfill];
+                                         }];
+
+  [self waitForExpectationsWithTimeout:kDefaultTimeout * 2 handler:nil];
+  XCTAssertEqual(writeError.code, GNSErrorNoConnection);
+}
+
+// The disconnection purge and the timeout deadline can both target the same write. Whichever runs
+// first wins and the other must find nothing left to complete.
+- (void)testRemoteDisconnectAndDataWriteTimeoutCompleteExactlyOnce {
+  [self simulateConnectedSocketWithPairingChar:NO];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"write completion"];
+  __block NSUInteger completionCount = 0;
+  [self startPendingDataWriteWithCompletion:^(NSError *error) {
+    completionCount++;
+    [expectation fulfill];
+  }];
+
+  _peripheral.state = CBPeripheralStateDisconnected;
+  [_centralPeerManager bleDisconnectedWithError:nil];
+  [self waitForExpectationsWithTimeout:kDefaultTimeout handler:nil];
+  XCTAssertEqual(completionCount, (NSUInteger)1);
+
+  [self waitForDataWriteTimeout];
+  XCTAssertEqual(completionCount, (NSUInteger)1);
+}
+
 @end

--- a/internal/platform/implementation/apple/Mediums/BLE/Sockets/Tests/Central/GNSCentralPeerManagerTest.m
+++ b/internal/platform/implementation/apple/Mediums/BLE/Sockets/Tests/Central/GNSCentralPeerManagerTest.m
@@ -878,4 +878,189 @@ static FakeTimer *gTimer;
   XCTAssertEqual(_socketDelegate.disconnectedError.code, GNSErrorUnexpectedWeaveControlPacket);
 }
 
+
+#pragma mark - Pending data write purged on disconnection
+
+// Starts a write-with-response that the fake peripheral never acknowledges, so the pending data
+// write completion stays installed until something else completes it.
+- (void)startPendingDataWriteWithCompletion:(GNSErrorHandler)completion {
+  [(id<GNSSocketOwner>)_centralPeerManager sendData:[@"data" dataUsingEncoding:NSUTF8StringEncoding]
+                                             socket:_socket
+                                         completion:completion];
+}
+
+// Waits until everything already queued on the main queue has run. The peer manager calls its
+// completions with -dispatch_async on that queue.
+- (void)drainMainQueue {
+  XCTestExpectation *drained = [self expectationWithDescription:@"main queue drained"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [drained fulfill];
+  });
+  [self waitForExpectationsWithTimeout:kDefaultTimeout handler:nil];
+}
+
+// A disconnection initiated by the remote peer reaches -bleDisconnected without going through
+// -disconnectingWithError:, which is the path that already purges the pending write. Without the
+// purge in -bleDisconnected the completion is never called and the caller waits forever.
+- (void)testRemoteDisconnectCompletesPendingDataWrite {
+  [self simulateConnectedSocketWithPairingChar:NO];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"write completion"];
+  __block NSError *writeError = nil;
+  [self startPendingDataWriteWithCompletion:^(NSError *error) {
+    writeError = error;
+    [expectation fulfill];
+  }];
+
+  NSError *disconnectError = [NSError errorWithDomain:@"domain" code:-42 userInfo:nil];
+  _peripheral.state = CBPeripheralStateDisconnected;
+  [_centralPeerManager bleDisconnectedWithError:disconnectError];
+
+  [self waitForExpectationsWithTimeout:kDefaultTimeout handler:nil];
+  XCTAssertEqual(writeError.code, GNSErrorLostConnection);
+}
+
+// A write callback that lands after the purge must not run the completion a second time.
+- (void)testRemoteDisconnectCompletesPendingDataWriteExactlyOnce {
+  [self simulateConnectedSocketWithPairingChar:NO];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"write completion"];
+  __block NSUInteger completionCount = 0;
+  [self startPendingDataWriteWithCompletion:^(NSError *error) {
+    completionCount++;
+    [expectation fulfill];
+  }];
+
+  _peripheral.state = CBPeripheralStateDisconnected;
+  [_centralPeerManager bleDisconnectedWithError:nil];
+  [self waitForExpectationsWithTimeout:kDefaultTimeout handler:nil];
+  XCTAssertEqual(completionCount, (NSUInteger)1);
+
+  [_centralPeerManager peripheral:(CBPeripheral *)_peripheral
+      didWriteValueForCharacteristic:(CBCharacteristic *)_toPeripheralCharacteristic
+                               error:nil];
+  [self drainMainQueue];
+  XCTAssertEqual(completionCount, (NSUInteger)1);
+}
+
+// The disconnection error may be nil. The write must still fail: passing nil through would be
+// reported to the caller as a successful write.
+- (void)testRemoteDisconnectWithNilErrorStillFailsPendingDataWrite {
+  [self simulateConnectedSocketWithPairingChar:NO];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"write completion"];
+  __block NSError *writeError = nil;
+  [self startPendingDataWriteWithCompletion:^(NSError *error) {
+    writeError = error;
+    [expectation fulfill];
+  }];
+
+  _peripheral.state = CBPeripheralStateDisconnected;
+  [_centralPeerManager bleDisconnectedWithError:nil];
+
+  [self waitForExpectationsWithTimeout:kDefaultTimeout handler:nil];
+  XCTAssertNotNil(writeError);
+  XCTAssertEqual(writeError.code, GNSErrorLostConnection);
+}
+
+// Regression: on the local path -disconnectingWithError: purges the write and -bleDisconnected
+// runs right after it. The second purge must find nothing left to complete.
+- (void)testLocalDisconnectCompletesPendingDataWriteExactlyOnce {
+  [self simulateConnectedSocketWithPairingChar:NO];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"write completion"];
+  __block NSUInteger completionCount = 0;
+  [self startPendingDataWriteWithCompletion:^(NSError *error) {
+    completionCount++;
+    [expectation fulfill];
+  }];
+
+  [_socket disconnect];
+  XCTAssertTrue(_centralManager.cancelConnectionCalled);
+  _peripheral.state = CBPeripheralStateDisconnected;
+  [_centralPeerManager bleDisconnectedWithError:nil];
+
+  [self waitForExpectationsWithTimeout:kDefaultTimeout handler:nil];
+  [self drainMainQueue];
+  XCTAssertEqual(completionCount, (NSUInteger)1);
+}
+
+// Disconnecting with no write in flight is a no-op for the write completion.
+- (void)testRemoteDisconnectWithoutPendingDataWriteIsNoOp {
+  [self simulateConnectedSocketWithPairingChar:NO];
+
+  _peripheral.state = CBPeripheralStateDisconnected;
+  [_centralPeerManager bleDisconnectedWithError:nil];
+
+  [self drainMainQueue];
+  XCTAssertTrue(_centralManager.didDisconnectCalled);
+  XCTAssertTrue(_socketDelegate.disconnectedCalled);
+}
+
+// A payload larger than the negotiated packet size is written one packet at a time, each one
+// waiting on the previous write completion. Losing the link mid-payload must fail the send
+// instead of stalling it.
+- (void)testRemoteDisconnectFailsSendSplitAcrossPackets {
+  [self simulateConnectedSocketWithPairingChar:NO];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"socket send completion"];
+  __block NSError *sendError = nil;
+  [_socket sendData:[NSMutableData dataWithLength:300]
+      progressHandler:^(float progress){
+      }
+           completion:^(NSError *error) {
+             sendError = error;
+             [expectation fulfill];
+           }];
+
+  _peripheral.state = CBPeripheralStateDisconnected;
+  [_centralPeerManager bleDisconnectedWithError:nil];
+
+  [self waitForExpectationsWithTimeout:kDefaultTimeout handler:nil];
+  XCTAssertNotNil(sendError);
+}
+
+// After the purge the peer manager is back to NotConnected and accepts a new socket request, so
+// the same peripheral can be reconnected without recreating the process.
+- (void)testPeerManagerAcceptsNewConnectionAfterRemoteDisconnectWithPendingWrite {
+  [self simulateConnectedSocketWithPairingChar:NO];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"write completion"];
+  [self startPendingDataWriteWithCompletion:^(NSError *error) {
+    [expectation fulfill];
+  }];
+
+  _peripheral.state = CBPeripheralStateDisconnected;
+  [_centralPeerManager bleDisconnectedWithError:nil];
+  [self waitForExpectationsWithTimeout:kDefaultTimeout handler:nil];
+
+  _socket = nil;
+  _centralManager.connectPeripheralCalled = NO;
+  [_centralPeerManager socketWithPairingCharacteristic:NO
+                                            completion:^(GNSSocket *socket, NSError *error){
+                                            }];
+  XCTAssertTrue(_centralManager.connectPeripheralCalled);
+}
+
+// Turning Bluetooth off disconnects the peripheral through the central manager, which is the same
+// remote path. The pending write must not survive it.
+- (void)testBluetoothPoweredOffCompletesPendingDataWrite {
+  [self simulateConnectedSocketWithPairingChar:NO];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"write completion"];
+  __block NSError *writeError = nil;
+  [self startPendingDataWriteWithCompletion:^(NSError *error) {
+    writeError = error;
+    [expectation fulfill];
+  }];
+
+  _centralManager.cbManagerState = CBCentralManagerStatePoweredOff;
+  [_centralPeerManager cbManagerStateDidUpdate];
+  _peripheral.state = CBPeripheralStateDisconnected;
+  [_centralPeerManager bleDisconnectedWithError:nil];
+
+  [self waitForExpectationsWithTimeout:kDefaultTimeout handler:nil];
+  XCTAssertEqual(writeError.code, GNSErrorLostConnection);
+}
+
 @end


### PR DESCRIPTION
## Problem

`GNSCentralPeerManager` does not complete a pending characteristic write when the
remote peer initiates the disconnection.

The class already handles the two neighbouring cases:

- the **local** disconnection path, `-disconnectingWithError:`, calls
  `-callDataWriteCompletionWithError:` before tearing the connection down;
- `-bleDisconnected` purges the pending **RSSI** completion through
  `-cleanRSSICompletionAfterDisconnectionWithError:`, and there is a test for it
  (`testCleanRSSICompletionAfterDisconnection`).

A disconnection initiated by the remote peer reaches `-bleDisconnected` through
`-bleDisconnectedWithError:`, which calls it directly and never passes through
`-disconnectingWithError:`. A write that is still waiting for
`-peripheral:didWriteValueForCharacteristic:` is therefore never completed.

The caller of `-sendData:socket:completion:` then waits forever. Because the
completion block retains the writer, the write queue above the socket stops
draining and the peer manager stays alive, which also keeps
`-retrieveCentralPeerWithIdentifier:` from handing out a new peer manager for the
same peripheral on a later reconnection — so the central cannot recover by
reconnecting either.

Reproducible on hardware: connect an iOS central to an advertising peer, start a
payload large enough to span several packets, and drop the link mid-payload (for
example by turning the peer's Bluetooth off). The send never returns and
subsequent discovery on that peripheral does not recover without restarting the
process.

## Changes

Two independent commits, so either can be reverted on its own.

**1. Complete the pending write in `-bleDisconnected`** — mirrors what the local
path already does. `-callDataWriteCompletionWithError:` clears the ivar before
dispatching, so a late `-peripheral:didWriteValueForCharacteristic:` cannot
complete the same write a second time.

**2. Fail a write whose socket is already disconnected when its deadline runs.**
The timeout block installed by `-sendData:socket:completion:` returns early when
`socket.isConnected` is `NO`, assuming the disconnection path has already
completed the write. That holds once the write is visible to the disconnection
path, but the caller runs on its own queue and can install a write after the
socket is gone; such a write has no deadline left to catch it. It now completes
with `GNSErrorNoConnection`. The existing 0.5 s deadline is unchanged.

Only `GNSCentralPeerManager.m` and its test file are touched. No public API
changes.

## Tests

Ten cases added to `GNSCentralPeerManagerTest.m`, using the existing fakes and
`FakeTimer`:

| Test | Covers |
| --- | --- |
| `testRemoteDisconnectCompletesPendingDataWrite` | the write fails with `GNSErrorLostConnection` |
| `testRemoteDisconnectCompletesPendingDataWriteExactlyOnce` | counts invocations; a late write callback does not complete twice |
| `testRemoteDisconnectWithNilErrorStillFailsPendingDataWrite` | a nil disconnection error must not be reported as a successful write |
| `testLocalDisconnectCompletesPendingDataWriteExactlyOnce` | regression: the local path purges once, not twice |
| `testRemoteDisconnectWithoutPendingDataWriteIsNoOp` | no write in flight |
| `testRemoteDisconnectFailsSendSplitAcrossPackets` | a payload spanning several packets fails instead of stalling |
| `testPeerManagerAcceptsNewConnectionAfterRemoteDisconnectWithPendingWrite` | the peer manager accepts a new socket request afterwards |
| `testBluetoothPoweredOffCompletesPendingDataWrite` | Bluetooth turned off mid-write |
| `testDataWriteTimeoutCompletesWriteInstalledAfterDisconnection` | the backstop from commit 2 |
| `testRemoteDisconnectAndDataWriteTimeoutCompleteExactlyOnce` | purge and deadline race, exactly one completion |

Reverting `GNSCentralPeerManager.m` to the base commit turns eight of these red;
the two that stay green are the regression guards, which are meant to pass either
way. No existing test changes result.

Note on how they were run: the Apple test targets in this repository are not
buildable from a public checkout — `Sockets/Tests/BUILD` loads
`//third_party/nearby:minimum_os.bzl` and depends on
`//third_party/apple_frameworks:*`, `//third_party/objective_c/ocmock/v3:OCMock`
and `//testing/utp/ios:IOS_LATEST`, none of which exist here, and `ios_unit_test`
is passed `google_create_srl_bindings_module`, which public `rules_apple` does not
accept. The tests were therefore executed by compiling `Sockets/Source/Central`,
`Sockets/Source/Shared` and the test file against public OCMock in a separate
harness: 48 tests, 0 failures. They are written against the existing harness in
this repo and should run unchanged in internal CI.

Base: `63513bdf76541f539f251a020109630da9730c74`.
